### PR TITLE
feat: Team Tournament Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,47 @@ All components use Tailwind CSS utility classes with the `dark:` prefix for them
 - [ ] Testing and quality assurance
 - [ ] Deployment and monitoring
 
+## Performance Optimizations
+
+### Future Improvement: Lazy Loading Player Data in Team Tournaments
+
+**Current Implementation (Option 1):**
+When loading team tournament results, the application:
+1. Fetches and displays team standings table immediately
+2. Fetches ALL player info for ALL games in the background (non-blocking)
+3. Player names appear in expanded match views once loaded
+
+This approach provides instant team standings display while player data loads in the background.
+
+**Potential Future Optimization (Option 2):**
+Implement lazy loading of player data on match expansion:
+
+**Benefits:**
+- **Reduced API load**: Only fetch players for matches the user actually expands
+- **Better API citizenship**: Spreads API calls over time instead of burst loading
+- **Faster initial load**: Zero player API calls on page load
+- **User-driven fetching**: Average user views 2-3 matches = ~60-80 API calls instead of ~420
+
+**Implementation Strategy:**
+1. On match expansion, extract player IDs from that specific match's games (~14-28 players)
+2. Check which players are already in the playerMap cache
+3. Fetch only missing players in parallel
+4. Display loading skeleton while fetching
+5. Cache all fetched players for subsequent expansions (no re-fetching needed)
+
+**Complexity Estimate:** ~3-4 hours of implementation
+- Add loading state per expanded match
+- Filter missing player IDs before fetching
+- Handle async fetch with loading/error states
+- Update playerMap via context when players loaded
+
+**When to Consider:**
+- If API rate limiting becomes an issue
+- If initial load time feedback from users
+- If analytics show most users don't expand all matches
+
+**Note:** Player data caching across expansions is correct behavior - player info doesn't change mid-session, and page refresh handles any updates.
+
 ## Getting Started
 
 ### Prerequisites

--- a/src/components/results/TeamFinalResultsTable.tsx
+++ b/src/components/results/TeamFinalResultsTable.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import React from 'react';
+import { Table, TableColumn, TableDensity, DensityThresholds } from '@/components/Table';
+import { TeamTournamentEndResultDto } from '@/lib/api/types';
+import { useLanguage } from '@/context/LanguageContext';
+import { getTranslation } from '@/lib/translations';
+
+export interface TeamFinalResultsTableProps {
+  /** Team tournament end results data */
+  results: TeamTournamentEndResultDto[];
+  /** Function to get club name from club ID */
+  getClubName: (clubId: number) => string;
+  /** Optional loading state */
+  loading?: boolean;
+  /** Optional error message */
+  error?: string;
+  /** Callback when a row is clicked */
+  onRowClick?: (result: TeamTournamentEndResultDto) => void;
+  /**
+   * Table density - controls padding and font size.
+   * If not provided, auto-density is enabled (compact on mobile, row-count based on desktop)
+   */
+  density?: TableDensity;
+  /**
+   * Thresholds for auto-density selection on desktop.
+   * Default: comfortable <= 10 rows, normal <= 20 rows, compact > 20 rows
+   */
+  densityThresholds?: DensityThresholds;
+}
+
+export function TeamFinalResultsTable({
+  results,
+  getClubName,
+  loading = false,
+  error,
+  onRowClick,
+  density,
+  densityThresholds
+}: TeamFinalResultsTableProps) {
+  const { language } = useLanguage();
+  const t = getTranslation(language);
+
+  const columns: TableColumn<TeamTournamentEndResultDto>[] = [
+    {
+      id: 'pos',
+      header: t.pages.tournamentResults.teamFinalResultsTable.pos,
+      accessor: 'place',
+      align: 'left',
+      noWrap: true
+    },
+    {
+      id: 'team',
+      header: t.pages.tournamentResults.teamFinalResultsTable.team,
+      accessor: (row) => getClubName(row.contenderId),
+      align: 'left'
+    },
+    {
+      id: 'sp',
+      header: t.pages.tournamentResults.teamFinalResultsTable.sp,
+      accessor: (row) => {
+        const matchesPlayed = (row.wonGames || 0) + (row.drawGames || 0) + (row.lostGames || 0);
+        return matchesPlayed || '-';
+      },
+      align: 'center',
+      noWrap: true
+    },
+    {
+      id: 'won',
+      header: t.pages.tournamentResults.teamFinalResultsTable.won,
+      accessor: (row) => row.wonGames !== undefined ? row.wonGames : '-',
+      align: 'center',
+      noWrap: true
+    },
+    {
+      id: 'draw',
+      header: t.pages.tournamentResults.teamFinalResultsTable.draw,
+      accessor: (row) => row.drawGames !== undefined ? row.drawGames : '-',
+      align: 'center',
+      noWrap: true
+    },
+    {
+      id: 'lost',
+      header: t.pages.tournamentResults.teamFinalResultsTable.lost,
+      accessor: (row) => row.lostGames !== undefined ? row.lostGames : '-',
+      align: 'center',
+      noWrap: true
+    },
+    {
+      id: 'pp',
+      header: t.pages.tournamentResults.teamFinalResultsTable.pp,
+      accessor: (row) => row.points !== undefined ? row.points.toFixed(2) : '-',
+      align: 'center',
+      noWrap: true,
+      cellStyle: { fontWeight: 'medium' }
+    },
+    {
+      id: 'mp',
+      header: t.pages.tournamentResults.teamFinalResultsTable.mp,
+      accessor: (row) => row.secPoints !== undefined ? (Math.round(Number(row.secPoints) * 2) / 2).toFixed(1) : '-',
+      align: 'center',
+      noWrap: true
+    }
+  ];
+
+  return (
+    <Table
+      data={results}
+      columns={columns}
+      loading={loading}
+      error={error}
+      emptyMessage={t.pages.tournamentResults.teamFinalResultsTable.noResults}
+      loadingMessage={t.pages.tournamentResults.teamFinalResultsTable.loadingResults}
+      onRowClick={onRowClick}
+      getRowKey={(row) => row.contenderId}
+      density={density}
+      densityThresholds={densityThresholds}
+    />
+  );
+}
+
+export default TeamFinalResultsTable;

--- a/src/components/results/TeamRoundResults.tsx
+++ b/src/components/results/TeamRoundResults.tsx
@@ -1,0 +1,275 @@
+'use client';
+
+import React, { useState, useMemo } from 'react';
+import { TournamentRoundResultDto, GameDto } from '@/lib/api/types';
+import { useLanguage } from '@/context/LanguageContext';
+import { getTranslation } from '@/lib/translations';
+import { Link } from '@/components/Link';
+import { Table, TableColumn } from '@/components/Table';
+
+export interface TeamRoundResultsProps {
+  /** Team round results data */
+  roundResults: TournamentRoundResultDto[];
+  /** Function to get club name from club ID */
+  getClubName: (clubId: number) => string;
+  /** Function to get player name from player ID */
+  getPlayerName: (playerId: number) => string;
+  /** Function to get player ELO from player ID */
+  getPlayerElo: (playerId: number) => string;
+  /** Tournament ID for player links */
+  tournamentId: number;
+  /** Group ID for player links */
+  groupId: number;
+}
+
+// Match represents a team matchup (multiple boards)
+interface TeamMatch {
+  roundNr: number;
+  homeId: number;
+  awayId: number;
+  homeScore: number;
+  awayScore: number;
+  date: string;
+  finalized: boolean;
+  boards: TournamentRoundResultDto[]; // All board results for this match
+}
+
+export function TeamRoundResults({
+  roundResults,
+  getClubName,
+  getPlayerName,
+  getPlayerElo,
+  tournamentId,
+  groupId
+}: TeamRoundResultsProps) {
+  const { language } = useLanguage();
+  const t = getTranslation(language);
+  const [selectedRound, setSelectedRound] = useState<number | null>(null);
+  const [expandedMatchIndex, setExpandedMatchIndex] = useState<number | null>(null);
+
+  // Group round results by round number and then by match (homeId, awayId)
+  const matchesByRound = useMemo(() => {
+    const grouped: Record<number, TeamMatch[]> = {};
+
+    roundResults.forEach(result => {
+      const round = result.roundNr || 1;
+      if (!grouped[round]) grouped[round] = [];
+
+      // Find existing match or create new one
+      const matchKey = `${result.homeId}-${result.awayId}`;
+      let match = grouped[round].find(m => `${m.homeId}-${m.awayId}` === matchKey);
+
+      if (!match) {
+        match = {
+          roundNr: round,
+          homeId: result.homeId,
+          awayId: result.awayId,
+          homeScore: 0,
+          awayScore: 0,
+          date: result.date,
+          finalized: result.finalized,
+          boards: []
+        };
+        grouped[round].push(match);
+      }
+
+      // Add board result to match
+      match.boards.push(result);
+      match.homeScore += result.homeResult || 0;
+      match.awayScore += result.awayResult || 0;
+    });
+
+    return grouped;
+  }, [roundResults]);
+
+  const rounds = Object.keys(matchesByRound)
+    .map(Number)
+    .sort((a, b) => a - b);
+
+  // Set default selected round if not set
+  if (selectedRound === null && rounds.length > 0) {
+    setSelectedRound(rounds[0]);
+  }
+
+  if (rounds.length === 0) {
+    return (
+      <div className="p-6 text-center">
+        <div className="text-gray-600 dark:text-gray-400">
+          {t.pages.tournamentResults.roundByRound.noResults}
+        </div>
+      </div>
+    );
+  }
+
+  const selectedMatches = selectedRound ? matchesByRound[selectedRound] : [];
+
+  // Toggle match expansion
+  const handleMatchClick = (index: number) => {
+    setExpandedMatchIndex(expandedMatchIndex === index ? null : index);
+  };
+
+  // Get game result display
+  const getGameResult = (result: number): string => {
+    if (result === 1) return '1 - 0';
+    if (result === 0) return '½ - ½';
+    if (result === -1) return '0 - 1';
+    return '-';
+  };
+
+  return (
+    <div className="rounded-lg border overflow-hidden bg-white dark:bg-dark-bg border-gray-200 dark:border-gray-700">
+      <div className="p-4 md:p-6 border-b border-gray-200 dark:border-gray-700">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-200">
+          {t.pages.tournamentResults.roundByRound.title}
+        </h3>
+      </div>
+
+      {/* Round Tab Navigation */}
+      <div className="flex overflow-x-auto border-b border-gray-200 dark:border-gray-700">
+        {rounds.map(roundNumber => (
+          <button
+            key={roundNumber}
+            onClick={() => {
+              setSelectedRound(roundNumber);
+              setExpandedMatchIndex(null); // Collapse when changing rounds
+            }}
+            className={`flex-shrink-0 px-4 py-3 text-sm font-medium whitespace-nowrap transition-colors ${
+              selectedRound === roundNumber
+                ? 'border-b-2 text-blue-600 dark:text-blue-400 border-blue-600 dark:border-blue-400'
+                : 'text-gray-600 dark:text-gray-400'
+            }`}
+          >
+            {t.pages.tournamentResults.roundByRound.round} {roundNumber}
+          </button>
+        ))}
+      </div>
+
+      {/* Selected Round Content */}
+      <div className="p-4 md:p-6">
+        <div className="space-y-2">
+          {selectedMatches.map((match, index) => (
+            <div key={index} className="border rounded-lg overflow-hidden border-gray-200 dark:border-gray-700">
+              {/* Match Header - Clickable */}
+              <button
+                onClick={() => handleMatchClick(index)}
+                className="w-full px-4 py-3 text-left hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex-1">
+                    <span className="font-medium text-gray-900 dark:text-gray-200">
+                      {getClubName(match.homeId)}
+                    </span>
+                    <span className="mx-2 text-gray-500 dark:text-gray-400">-</span>
+                    <span className="font-medium text-gray-900 dark:text-gray-200">
+                      {getClubName(match.awayId)}
+                    </span>
+                  </div>
+                  <div className="ml-4 flex items-center gap-3">
+                    <span className="font-semibold text-gray-900 dark:text-gray-200">
+                      {match.homeScore} - {match.awayScore}
+                    </span>
+                    <svg
+                      className={`w-5 h-5 text-gray-400 transition-transform ${
+                        expandedMatchIndex === index ? 'rotate-180' : ''
+                      }`}
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                    </svg>
+                  </div>
+                </div>
+              </button>
+
+              {/* Expanded Board Games */}
+              {expandedMatchIndex === index && (
+                <div className="border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50">
+                  <div className="p-4">
+                    {(() => {
+                      // Get all games from this match (match.boards[0] contains the TournamentRoundResultDto)
+                      const allGames = match.boards[0]?.games || [];
+
+                      // Create columns for board games table
+                      const boardColumns: TableColumn<GameDto>[] = [
+                        {
+                          id: 'board',
+                          header: t.pages.tournamentResults.teamRoundResults.board,
+                          accessor: (game) => game.tableNr !== undefined ? game.tableNr + 1 : '-',
+                          align: 'left',
+                          noWrap: true
+                        },
+                        {
+                          id: 'homePlayer',
+                          header: t.pages.tournamentResults.teamRoundResults.homeTeam,
+                          accessor: (game) => (
+                            <Link
+                              href={`/results/${tournamentId}/${groupId}/${game.whiteId}`}
+                              color="gray"
+                            >
+                              {getPlayerName(game.whiteId)}
+                            </Link>
+                          ),
+                          align: 'left'
+                        },
+                        {
+                          id: 'homeElo',
+                          header: t.pages.tournamentResults.teamRoundResults.elo,
+                          accessor: (game) => getPlayerElo(game.whiteId),
+                          align: 'center',
+                          noWrap: true
+                        },
+                        {
+                          id: 'awayPlayer',
+                          header: t.pages.tournamentResults.teamRoundResults.awayTeam,
+                          accessor: (game) => (
+                            <Link
+                              href={`/results/${tournamentId}/${groupId}/${game.blackId}`}
+                              color="gray"
+                            >
+                              {getPlayerName(game.blackId)}
+                            </Link>
+                          ),
+                          align: 'left'
+                        },
+                        {
+                          id: 'awayElo',
+                          header: t.pages.tournamentResults.teamRoundResults.elo,
+                          accessor: (game) => getPlayerElo(game.blackId),
+                          align: 'center',
+                          noWrap: true
+                        },
+                        {
+                          id: 'result',
+                          header: t.pages.tournamentResults.teamRoundResults.result,
+                          accessor: (game) => getGameResult(game.result),
+                          align: 'center',
+                          noWrap: true,
+                          cellStyle: { fontWeight: 'medium' }
+                        }
+                      ];
+
+                      // Sort games by table number
+                      const sortedGames = [...allGames].sort((a, b) => (a.tableNr || 0) - (b.tableNr || 0));
+
+                      return (
+                        <Table
+                          data={sortedGames}
+                          columns={boardColumns}
+                          getRowKey={(game) => game.id.toString()}
+                          density="compact"
+                        />
+                      );
+                    })()}
+                  </div>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default TeamRoundResults;

--- a/src/context/GroupResultsContext.tsx
+++ b/src/context/GroupResultsContext.tsx
@@ -1,19 +1,32 @@
 'use client';
 
 import { createContext, useContext } from 'react';
-import { TournamentEndResultDto, TournamentRoundResultDto, PlayerInfoDto } from '@/lib/api/types';
+import { TournamentEndResultDto, TournamentRoundResultDto, PlayerInfoDto, TeamTournamentEndResultDto } from '@/lib/api/types';
 
 export interface GroupResultsContextValue {
-  groupResults: TournamentEndResultDto[];
-  roundResults: TournamentRoundResultDto[];
+  // Tournament type detection
+  isTeamTournament: boolean;
+
+  // Individual tournament fields
+  individualResults: TournamentEndResultDto[];
+  individualRoundResults: TournamentRoundResultDto[];
+
+  // Team tournament fields
+  teamResults: TeamTournamentEndResultDto[];
+  teamRoundResults: TournamentRoundResultDto[];
+
+  // Shared fields
   playerMap: Map<number, PlayerInfoDto>;
   thinkingTime: string | null;
   groupStartDate: string | null;
   groupEndDate: string | null;
   loading: boolean;
   error: string | null;
+
+  // Helper functions
   getPlayerName: (playerId: number) => string;
   getPlayerElo: (playerId: number) => string;
+  getClubName: (clubId: number) => string;
 }
 
 const GroupResultsContext = createContext<GroupResultsContextValue | null>(null);

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -227,6 +227,18 @@ export interface Translations {
         noResults: string;
         loadingResults: string;
       };
+      teamFinalResultsTable: {
+        pos: string;
+        team: string;
+        sp: string;
+        won: string;
+        draw: string;
+        lost: string;
+        pp: string;
+        mp: string;
+        noResults: string;
+        loadingResults: string;
+      };
       roundByRound: {
         title: string;
         white: string;
@@ -236,6 +248,13 @@ export interface Translations {
         result: string;
         noResults: string;
         round: string;
+      };
+      teamRoundResults: {
+        board: string;
+        homeTeam: string;
+        awayTeam: string;
+        elo: string;
+        result: string;
       };
       selectGroup: string;
       tournamentStatus: {
@@ -477,6 +496,18 @@ const translations: Record<Language, Translations> = {
           noResults: 'No results available for this group',
           loadingResults: 'Loading results...',
         },
+        teamFinalResultsTable: {
+          pos: 'Pos',
+          team: 'Team',
+          sp: 'MP',
+          won: '+',
+          draw: '=',
+          lost: '-',
+          pp: 'BP',
+          mp: 'Pts',
+          noResults: 'No results available for this group',
+          loadingResults: 'Loading results...',
+        },
         roundByRound: {
           title: 'Rounds',
           white: 'White',
@@ -486,6 +517,13 @@ const translations: Record<Language, Translations> = {
           result: 'Result',
           noResults: 'No round results available for this group',
           round: 'Round',
+        },
+        teamRoundResults: {
+          board: 'Board',
+          homeTeam: 'Home',
+          awayTeam: 'Away',
+          elo: 'ELO',
+          result: 'Result',
         },
         selectGroup: 'Please select a group to view results',
         tournamentStatus: {
@@ -722,7 +760,18 @@ const translations: Record<Language, Translations> = {
           lost: '-',
           points: 'P',
           qp: 'KP',
-
+          noResults: 'Inga resultat tillgängliga för denna grupp',
+          loadingResults: 'Laddar resultat...',
+        },
+        teamFinalResultsTable: {
+          pos: 'Plac',
+          team: 'Lag',
+          sp: 'MP',
+          won: '+',
+          draw: '=',
+          lost: '-',
+          pp: 'BP',
+          mp: 'P',
           noResults: 'Inga resultat tillgängliga för denna grupp',
           loadingResults: 'Laddar resultat...',
         },
@@ -735,6 +784,13 @@ const translations: Record<Language, Translations> = {
           result: 'Resultat',
           noResults: 'Inga rondresultat tillgängliga för denna grupp',
           round: 'Rond',
+        },
+        teamRoundResults: {
+          board: 'Bräde',
+          homeTeam: 'Hemma',
+          awayTeam: 'Borta',
+          elo: 'ELO',
+          result: 'Resultat',
         },
         selectGroup: 'Vänligen välj en grupp för att se resultat',
         tournamentStatus: {


### PR DESCRIPTION
## Overview
Implements comprehensive support for team tournaments alongside existing individual tournament functionality. Team tournaments are automatically detected via `tournament.type === 2` and display team-based results with expandable board-level game details.

## Key Features

### ✨ Team Tournament Display
- **Team Standings Table**: Shows club names, match points (MP), board points (BP), and match results (+/=/-)
- **Expandable Match Details**: Click any team matchup to see all board games with player names, ELOs, and results
- **Player Detail Pages**: Click individual players to view their tournament stats and matches

### ⚡ Performance Optimization
- Team standings table appears **instantly** on page load
- Player info fetches in background (non-blocking)
- ~100+ parallel API calls don't block UI rendering
- Future lazy-loading optimization documented in README

### 🏗️ Architecture
- Clean separation: `individualResults` vs `teamResults`, `individualRoundResults` vs `teamRoundResults`
- Context provides `isTeamTournament` flag for conditional rendering
- Added `getClubName` helper for team name resolution
- Player info loaded via parallel API calls and cached in playerMap

## Components Added

1. **TeamFinalResultsTable** (`src/components/results/TeamFinalResultsTable.tsx`)
   - Displays team standings with club names
   - Columns: Pos, Team, MP, +/=/-, BP, Pts

2. **TeamRoundResults** (`src/components/results/TeamRoundResults.tsx`)
   - Round-by-round team matchups with scores
   - Expandable board games with player names and results
   - Links to individual player detail pages

## Files Modified

- `src/context/GroupResultsContext.tsx` - Extended with team tournament fields
- `src/app/results/[tournamentId]/[groupId]/layout.tsx` - Conditional data fetching and background player loading
- `src/app/results/[tournamentId]/[groupId]/page.tsx` - Conditional rendering for team vs individual
- `src/app/results/[tournamentId]/[groupId]/[memberId]/page.tsx` - Team tournament player match extraction
- `src/lib/translations.ts` - Added Swedish/English translations for team UI
- `README.md` - Documented future lazy-loading optimization strategy

## Testing

Tested with:
- **Tournament ID**: 5941
- **Group ID**: 16825
- Verified: Team table, expanded matches, player links, player detail pages

## Screenshots

### Before
- Team tournaments showed "Results coming soon..."
- No way to view team matchups or board games

### After
- Instant team standings table
- Expandable match details with all board games
- Player names and ELO ratings
- Clickable player links to detail pages

## Future Enhancements

Option 2 optimization documented in README: Lazy load player data only when user expands a match (reduces API calls from ~420 to ~60-80 average case).