### PR TITLE
feat: add tournament filters to calendar and results pages

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -13,6 +13,7 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   startIcon?: ReactNode;
   endIcon?: ReactNode;
   fullWidth?: boolean;
+  compact?: boolean;
 }
 
 const colorStyles = {
@@ -57,13 +58,15 @@ export function Button({
   startIcon,
   endIcon,
   fullWidth = false,
+  compact = false,
   ...props
 }: ButtonProps) {
-  const baseStyles = 'inline-flex items-center justify-center px-4 py-2 rounded transition-colors';
+  const baseStyles = 'inline-flex items-center justify-center rounded transition-colors';
+  const sizeStyles = compact ? 'px-3 py-1.5 text-sm' : 'px-4 py-2';
   const widthStyles = fullWidth ? 'w-full' : '';
   const variantStyles = colorStyles[color][variant];
 
-  const combinedStyles = `${baseStyles} ${widthStyles} ${variantStyles} ${className}`;
+  const combinedStyles = `${baseStyles} ${sizeStyles} ${widthStyles} ${variantStyles} ${className}`;
 
   const content = (
     <>

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -14,6 +14,7 @@ export interface TextFieldProps {
   placeholder?: string;
   type?: string;
   disabled?: boolean;
+  compact?: boolean;
 }
 
 export function TextField({
@@ -28,6 +29,7 @@ export function TextField({
   placeholder,
   type = 'text',
   disabled = false,
+  compact = false,
 }: TextFieldProps) {
   const marginClass = {
     none: '',
@@ -36,20 +38,14 @@ export function TextField({
   }[margin];
 
   const widthClass = fullWidth ? 'w-full' : '';
+  const sizeClasses = compact ? 'px-3 py-1.5 text-sm' : 'px-3 py-2';
 
-  const baseInputClasses = `
-    px-3 py-2
-    bg-transparent
-    border border-gray-300 dark:border-gray-600
-    rounded
-    text-gray-900 dark:text-gray-200
-    placeholder:text-gray-600 dark:placeholder:text-gray-400
-    focus:outline-none
-    focus:border-blue-500
-    hover:border-gray-900 dark:hover:border-white
-    ${disabled ? 'opacity-50 cursor-not-allowed' : ''}
-    ${widthClass}
-  `;
+  // Date inputs need special handling for the calendar icon in dark mode
+  const dateInputClasses = type === 'date'
+    ? 'min-w-0 dark:[&::-webkit-calendar-picker-indicator]:invert dark:[&::-webkit-calendar-picker-indicator]:opacity-70 [&::-webkit-calendar-picker-indicator]:cursor-pointer'
+    : '';
+
+  const baseInputClasses = `${sizeClasses} bg-transparent border border-gray-300 dark:border-gray-600 rounded text-gray-900 dark:text-gray-200 placeholder:text-gray-600 dark:placeholder:text-gray-400 focus:outline-none focus:border-blue-500 hover:border-gray-900 dark:hover:border-white ${disabled ? 'opacity-50 cursor-not-allowed' : ''} ${widthClass} ${dateInputClasses}`;
 
   return (
     <div className={`${marginClass} ${widthClass}`}>

--- a/src/components/filters/TournamentCategoryFilter.tsx
+++ b/src/components/filters/TournamentCategoryFilter.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { SelectableList, SelectableListItem } from '../SelectableList';
+import { getTranslation } from '@/lib/translations';
+import { TournamentCategory, CategoryCounts } from '@/lib/utils/tournamentFilters';
+
+interface TournamentCategoryFilterProps {
+  selectedCategory: TournamentCategory;
+  onCategorySelect: (category: TournamentCategory) => void;
+  counts?: CategoryCounts;
+  language: 'sv' | 'en';
+  variant?: 'dropdown' | 'vertical';
+  compact?: boolean;
+  transparent?: boolean;
+  showLabel?: boolean;
+}
+
+export function TournamentCategoryFilter({
+  selectedCategory,
+  onCategorySelect,
+  counts,
+  language,
+  variant = 'dropdown',
+  compact,
+  transparent,
+  showLabel = true,
+}: TournamentCategoryFilterProps) {
+  const t = getTranslation(language);
+
+  const items: SelectableListItem[] = [
+    {
+      id: 'all',
+      label: counts ? `${t.components.tournamentCategoryFilter.all} (${counts.all})` : t.components.tournamentCategoryFilter.all,
+    },
+    {
+      id: 'team',
+      label: counts ? `${t.components.tournamentCategoryFilter.team} (${counts.team})` : t.components.tournamentCategoryFilter.team,
+    },
+    {
+      id: 'individual',
+      label: counts ? `${t.components.tournamentCategoryFilter.individual} (${counts.individual})` : t.components.tournamentCategoryFilter.individual,
+    },
+  ];
+
+  const handleSelect = (id: string | number) => {
+    onCategorySelect(id as TournamentCategory);
+  };
+
+  return (
+    <SelectableList
+      items={items}
+      selectedId={selectedCategory}
+      onSelect={handleSelect}
+      title={showLabel ? t.components.tournamentCategoryFilter.label : undefined}
+      variant={variant}
+      compact={compact}
+      transparent={transparent}
+    />
+  );
+}

--- a/src/components/filters/TournamentStateFilter.tsx
+++ b/src/components/filters/TournamentStateFilter.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { SelectableList, SelectableListItem } from '../SelectableList';
+import { getTranslation } from '@/lib/translations';
+import { TournamentState } from '@/lib/api';
+import { StateCounts } from '@/lib/utils/tournamentFilters';
+
+interface TournamentStateFilterProps {
+  selectedState: number | null;
+  onStateSelect: (state: number | null) => void;
+  counts?: StateCounts;
+  language: 'sv' | 'en';
+  variant?: 'dropdown' | 'vertical';
+  compact?: boolean;
+  transparent?: boolean;
+  showLabel?: boolean;
+}
+
+export function TournamentStateFilter({
+  selectedState,
+  onStateSelect,
+  counts,
+  language,
+  variant = 'dropdown',
+  compact,
+  transparent,
+  showLabel = true,
+}: TournamentStateFilterProps) {
+  const t = getTranslation(language);
+  const stateTranslations = t.components.tournamentStateFilter;
+
+  const items: SelectableListItem[] = [
+    {
+      id: 'all',
+      label: counts ? `${stateTranslations.all} (${counts.all})` : stateTranslations.all,
+    },
+  ];
+
+  // Add registration option
+  if (!counts || counts.registration > 0) {
+    items.push({
+      id: TournamentState.REGISTRATION,
+      label: counts
+        ? `${stateTranslations.registration} (${counts.registration})`
+        : stateTranslations.registration,
+    });
+  }
+
+  // Add started option
+  if (!counts || counts.started > 0) {
+    items.push({
+      id: TournamentState.STARTED,
+      label: counts
+        ? `${stateTranslations.started} (${counts.started})`
+        : stateTranslations.started,
+    });
+  }
+
+  // Add finished option
+  if (!counts || counts.finished > 0) {
+    items.push({
+      id: TournamentState.FINISHED,
+      label: counts
+        ? `${stateTranslations.finished} (${counts.finished})`
+        : stateTranslations.finished,
+    });
+  }
+
+  const handleSelect = (id: string | number) => {
+    if (id === 'all') {
+      onStateSelect(null);
+    } else {
+      onStateSelect(Number(id));
+    }
+  };
+
+  return (
+    <SelectableList
+      items={items}
+      selectedId={selectedState ?? 'all'}
+      onSelect={handleSelect}
+      title={showLabel ? stateTranslations.label : undefined}
+      variant={variant}
+      compact={compact}
+      transparent={transparent}
+    />
+  );
+}

--- a/src/components/filters/TournamentTypeFilter.tsx
+++ b/src/components/filters/TournamentTypeFilter.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { SelectableList, SelectableListItem } from '../SelectableList';
+import { getTranslation } from '@/lib/translations';
+import { TypeCounts, getAllTournamentTypes, getTournamentTypeKey } from '@/lib/utils/tournamentFilters';
+
+interface TournamentTypeFilterProps {
+  selectedType: number | null;
+  onTypeSelect: (type: number | null) => void;
+  counts?: TypeCounts;
+  language: 'sv' | 'en';
+  variant?: 'dropdown' | 'vertical';
+  compact?: boolean;
+  transparent?: boolean;
+  showLabel?: boolean;
+}
+
+export function TournamentTypeFilter({
+  selectedType,
+  onTypeSelect,
+  counts,
+  language,
+  variant = 'dropdown',
+  compact,
+  transparent,
+  showLabel = true,
+}: TournamentTypeFilterProps) {
+  const t = getTranslation(language);
+  const typeTranslations = t.components.tournamentTypeFilter;
+
+  // Build items starting with "All"
+  const items: SelectableListItem[] = [
+    {
+      id: 'all',
+      label: counts ? `${typeTranslations.all} (${counts.all})` : typeTranslations.all,
+    },
+  ];
+
+  // Add each tournament type
+  getAllTournamentTypes().forEach(type => {
+    const count = counts?.[type];
+    // Skip types with no tournaments if counts are provided
+    if (counts && (!count || count === 0)) {
+      return;
+    }
+
+    const key = getTournamentTypeKey(type) as keyof typeof typeTranslations;
+    const label = typeTranslations[key] || `Type ${type}`;
+
+    items.push({
+      id: type,
+      label: count !== undefined ? `${label} (${count})` : label,
+    });
+  });
+
+  const handleSelect = (id: string | number) => {
+    if (id === 'all') {
+      onTypeSelect(null);
+    } else {
+      onTypeSelect(Number(id));
+    }
+  };
+
+  return (
+    <SelectableList
+      items={items}
+      selectedId={selectedType ?? 'all'}
+      onSelect={handleSelect}
+      title={showLabel ? typeTranslations.label : undefined}
+      variant={variant}
+      compact={compact}
+      transparent={transparent}
+    />
+  );
+}

--- a/src/components/filters/index.ts
+++ b/src/components/filters/index.ts
@@ -1,0 +1,3 @@
+export { TournamentCategoryFilter } from './TournamentCategoryFilter';
+export { TournamentTypeFilter } from './TournamentTypeFilter';
+export { TournamentStateFilter } from './TournamentStateFilter';

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -94,6 +94,31 @@ export interface Translations {
       teamTournamentHistory: string;
       opponentStatistics: string;
     };
+    tournamentCategoryFilter: {
+      label: string;
+      all: string;
+      team: string;
+      individual: string;
+    };
+    tournamentTypeFilter: {
+      label: string;
+      all: string;
+      allsvenskan: string;
+      individual: string;
+      smTree: string;
+      schoolSm: string;
+      svenskaCupen: string;
+      grandPrix: string;
+      yes2chess: string;
+      schackfyran: string;
+    };
+    tournamentStateFilter: {
+      label: string;
+      all: string;
+      registration: string;
+      started: string;
+      finished: string;
+    };
   };
   pages: {
     events: {
@@ -451,6 +476,31 @@ const translations: Record<Language, Translations> = {
         teamTournamentHistory: 'Team tournament history coming soon',
         opponentStatistics: 'Opponent statistics coming soon',
       },
+      tournamentCategoryFilter: {
+        label: 'Category',
+        all: 'All',
+        team: 'Team',
+        individual: 'Individual',
+      },
+      tournamentTypeFilter: {
+        label: 'Type',
+        all: 'All',
+        allsvenskan: 'Allsvenskan',
+        individual: 'Individual',
+        smTree: 'SM-Trean',
+        schoolSm: 'Skol-SM',
+        svenskaCupen: 'Svenska Cupen',
+        grandPrix: 'Grand Prix',
+        yes2chess: 'Yes2Chess',
+        schackfyran: 'Schackfyran',
+      },
+      tournamentStateFilter: {
+        label: 'Status',
+        all: 'All',
+        registration: 'Registration',
+        started: 'In Progress',
+        finished: 'Finished',
+      },
     },
     pages: {
       events: {
@@ -805,6 +855,31 @@ const translations: Record<Language, Translations> = {
       playerHistory: {
         teamTournamentHistory: 'Lagturneringshistorik kommer snart',
         opponentStatistics: 'Motståndarstatistik kommer snart',
+      },
+      tournamentCategoryFilter: {
+        label: 'Kategori',
+        all: 'Alla',
+        team: 'Lag',
+        individual: 'Individuell',
+      },
+      tournamentTypeFilter: {
+        label: 'Typ',
+        all: 'Alla',
+        allsvenskan: 'Allsvenskan',
+        individual: 'Individuell',
+        smTree: 'SM-Trean',
+        schoolSm: 'Skol-SM',
+        svenskaCupen: 'Svenska Cupen',
+        grandPrix: 'Grand Prix',
+        yes2chess: 'Yes2Chess',
+        schackfyran: 'Schackfyran',
+      },
+      tournamentStateFilter: {
+        label: 'Status',
+        all: 'Alla',
+        registration: 'Anmälan öppen',
+        started: 'Pågående',
+        finished: 'Avslutad',
       },
     },
     pages: {

--- a/src/lib/utils/tournamentFilters.ts
+++ b/src/lib/utils/tournamentFilters.ts
@@ -1,0 +1,178 @@
+/**
+ * Utility functions for filtering tournaments by category, type, and state
+ */
+
+import { TournamentDto, TournamentType, TournamentState, isTeamTournament } from '@/lib/api';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type TournamentCategory = 'all' | 'team' | 'individual';
+
+export interface CategoryCounts {
+  all: number;
+  team: number;
+  individual: number;
+}
+
+export interface StateCounts {
+  all: number;
+  registration: number;
+  started: number;
+  finished: number;
+}
+
+export type TypeCounts = Record<number | 'all', number>;
+
+// =============================================================================
+// Count Functions
+// =============================================================================
+
+/**
+ * Count tournaments by category (team vs individual)
+ */
+export function countByCategory(tournaments: TournamentDto[]): CategoryCounts {
+  const counts: CategoryCounts = { all: 0, team: 0, individual: 0 };
+
+  tournaments.forEach(t => {
+    counts.all++;
+    if (isTeamTournament(t.type)) {
+      counts.team++;
+    } else {
+      counts.individual++;
+    }
+  });
+
+  return counts;
+}
+
+/**
+ * Count tournaments by type
+ */
+export function countByType(tournaments: TournamentDto[]): TypeCounts {
+  const counts: TypeCounts = { all: tournaments.length };
+
+  tournaments.forEach(t => {
+    counts[t.type] = (counts[t.type] || 0) + 1;
+  });
+
+  return counts;
+}
+
+/**
+ * Count tournaments by state
+ */
+export function countByState(tournaments: TournamentDto[]): StateCounts {
+  const counts: StateCounts = { all: 0, registration: 0, started: 0, finished: 0 };
+
+  tournaments.forEach(t => {
+    counts.all++;
+    if (t.state === TournamentState.REGISTRATION) {
+      counts.registration++;
+    } else if (t.state === TournamentState.STARTED) {
+      counts.started++;
+    } else if (t.state === TournamentState.FINISHED) {
+      counts.finished++;
+    }
+  });
+
+  return counts;
+}
+
+// =============================================================================
+// Filter Functions
+// =============================================================================
+
+/**
+ * Filter tournaments by category
+ */
+export function filterByCategory(
+  tournaments: TournamentDto[],
+  category: TournamentCategory
+): TournamentDto[] {
+  if (category === 'all') {
+    return tournaments;
+  }
+
+  return tournaments.filter(t => {
+    const isTeam = isTeamTournament(t.type);
+    return category === 'team' ? isTeam : !isTeam;
+  });
+}
+
+/**
+ * Filter tournaments by type
+ * @param type - Tournament type number, or null for all types
+ */
+export function filterByType(
+  tournaments: TournamentDto[],
+  type: number | null
+): TournamentDto[] {
+  if (type === null) {
+    return tournaments;
+  }
+
+  return tournaments.filter(t => t.type === type);
+}
+
+/**
+ * Filter tournaments by state
+ * @param state - Tournament state number, or null for all states
+ */
+export function filterByState(
+  tournaments: TournamentDto[],
+  state: number | null
+): TournamentDto[] {
+  if (state === null) {
+    return tournaments;
+  }
+
+  return tournaments.filter(t => t.state === state);
+}
+
+// =============================================================================
+// Tournament Type Helpers
+// =============================================================================
+
+/**
+ * Get all tournament types for filter options
+ */
+export function getAllTournamentTypes(): number[] {
+  return [
+    TournamentType.ALLSVENSKAN,
+    TournamentType.INDIVIDUAL,
+    TournamentType.SM_TREE,
+    TournamentType.SCHOOL_SM,
+    TournamentType.SVENSKA_CUPEN,
+    TournamentType.GRAND_PRIX,
+    TournamentType.YES2CHESS,
+    TournamentType.SCHACKFYRAN,
+  ];
+}
+
+/**
+ * Get tournament type name key for translations
+ */
+export function getTournamentTypeKey(type: number): string {
+  switch (type) {
+    case TournamentType.ALLSVENSKAN:
+      return 'allsvenskan';
+    case TournamentType.INDIVIDUAL:
+      return 'individual';
+    case TournamentType.SM_TREE:
+      return 'smTree';
+    case TournamentType.SCHOOL_SM:
+      return 'schoolSm';
+    case TournamentType.SVENSKA_CUPEN:
+      return 'svenskaCupen';
+    case TournamentType.GRAND_PRIX:
+      return 'grandPrix';
+    case TournamentType.YES2CHESS:
+      return 'yes2chess';
+    case TournamentType.SCHACKFYRAN:
+      return 'schackfyran';
+    default:
+      return 'unknown';
+  }
+}


### PR DESCRIPTION
## Summary
- Add Category, Type, and State filters to Calendar and Results pages
- Create reusable filter components with counts
- Add compact mode to Button and TextField components
- Fix date input calendar icon visibility in dark mode
- Restructure Results page layout with search/filters separation

## Changes
- **New components**: `TournamentCategoryFilter`, `TournamentTypeFilter`, `TournamentStateFilter`
- **New utilities**: `src/lib/utils/tournamentFilters.ts` with filter and count functions
- **Calendar page**: Added all 4 filters (District, Category, Type, State) in responsive grid
- **Results page**: Reorganized with search section on top, divider, then filters below
- **Button/TextField**: Added `compact` prop for consistent sizing
- **TextField**: Fixed dark mode calendar picker icon visibility

## Test plan
- [ ] Verify Calendar page filters work and show correct counts
- [ ] Verify Results page search and filters work together
- [ ] Test on mobile viewports (filters should stay on one row)
- [ ] Verify dark mode calendar icon is visible
- [ ] Test filter chaining (Category → Type → State)