### PR TITLE
feat: add About, Contact, and Changelog pages with rebranding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,93 @@
+# Changelog
+
+All notable changes to msvens chess will be documented in this file.
+
+## [Unreleased]
+
+### Added
+- Contact page for user feedback (Formspree integration pending)
+- Changelog page with structured version history
+- Changelog generation script (`yarn generate:changelog`)
+- Bilingual About page with project background and acknowledgments
+
+### Changed
+- Rebranded from "Stockholm Chess" to "msvens chess"
+- Updated site metadata and descriptions to focus on Sweden-wide coverage
+- Footer navigation now links to About, Contact, and Changelog
+- Footer styling: larger text on desktop, increased padding
+
+---
+
+## [0.4.0] - 2025-01-20
+
+### Added
+- Tournament filters for calendar and results pages (category, type, status, district)
+- Comprehensive game result handling for all point systems
+- PageTitle component for consistent page headers
+
+### Fixed
+- Mobile navbar now shows Results and Players icons
+- Deduplicated tournament search results
+
+### Changed
+- Improved translation system with common section for shared strings
+
+---
+
+## [0.3.0] - 2025-01-15
+
+### Added
+- Organizations page with clubs and districts browser
+- Club rating lists with filtering by rating type and member category
+- Opponents statistics page with progressive loading
+- Batch API methods for efficient multi-ID fetching
+- Player rating history with batched requests
+
+### Changed
+- Unified player page tournament data from games
+- Optimized imports with centralized @/lib/api exports
+- Enhanced rating display on tournament result pages
+
+---
+
+## [0.2.0] - 2025-01-10
+
+### Added
+- Team tournament support with expandable match details
+- Club-based player assignments for team tournaments
+- W.O. (walkover) handling for forfeited games
+- Results page with date range and text search
+- Tournament timestamp column showing last update
+
+### Changed
+- Centralized API environment configuration
+- Simplified player search with recent players in localStorage
+
+### Fixed
+- Team tournament result display improvements
+
+---
+
+## [0.1.0] - 2025-01-05
+
+### Added
+- Initial release of msvens chess (then Stockholm Chess)
+- Tournament calendar with upcoming events
+- Tournament results browser
+- Player search by name or member ID
+- Player profiles with:
+  - ELO ratings (standard, rapid, blitz)
+  - LASK ratings
+  - Tournament history with tabbed navigation
+  - ELO rating history chart
+  - Player photos from SSF
+- Round-by-round results for individual tournaments
+- Dark/light theme support
+- English and Swedish language support
+- Mobile-responsive design
+
+### Infrastructure
+- Next.js 15 with App Router
+- Tailwind CSS for styling
+- API service layer for SSF tournament data
+- Jest testing setup

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "test:api": "tsx src/lib/api/test-runner.ts",
     "test": "jest",
     "test:watch": "jest --watch",
-    "translations:check": "tsx scripts/check-translations.ts"
+    "translations:check": "tsx scripts/check-translations.ts",
+    "generate:changelog": "tsx scripts/generate-changelog.ts",
+    "predev": "yarn generate:changelog",
+    "prebuild": "yarn generate:changelog"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",

--- a/scripts/generate-changelog.ts
+++ b/scripts/generate-changelog.ts
@@ -1,0 +1,140 @@
+#!/usr/bin/env npx tsx
+/**
+ * Changelog Generator
+ *
+ * Reads CHANGELOG.md from the project root and generates a typed TypeScript
+ * file with structured changelog data.
+ *
+ * Run manually: yarn generate:changelog
+ * Runs automatically: as part of predev and prebuild
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT_DIR = path.join(__dirname, '..');
+const CHANGELOG_MD = path.join(ROOT_DIR, 'CHANGELOG.md');
+const OUTPUT_FILE = path.join(ROOT_DIR, 'src', 'data', 'changelog.ts');
+
+interface ChangelogSection {
+  type: string;
+  items: string[];
+}
+
+interface ChangelogEntry {
+  version: string;
+  date: string | null;
+  sections: ChangelogSection[];
+}
+
+function parseChangelog(content: string): ChangelogEntry[] {
+  const entries: ChangelogEntry[] = [];
+  const lines = content.split('\n');
+
+  let currentEntry: ChangelogEntry | null = null;
+  let currentSection: ChangelogSection | null = null;
+
+  for (const line of lines) {
+    // Match version headers: ## [0.4.0] - 2025-01-20 or ## [Unreleased]
+    const versionMatch = line.match(/^## \[([^\]]+)\](?:\s*-\s*(\d{4}-\d{2}-\d{2}))?/);
+    if (versionMatch) {
+      if (currentEntry) {
+        if (currentSection && currentSection.items.length > 0) {
+          currentEntry.sections.push(currentSection);
+        }
+        entries.push(currentEntry);
+      }
+      currentEntry = {
+        version: versionMatch[1],
+        date: versionMatch[2] || null,
+        sections: [],
+      };
+      currentSection = null;
+      continue;
+    }
+
+    // Match section headers: ### Added, ### Changed, etc.
+    const sectionMatch = line.match(/^### (.+)/);
+    if (sectionMatch && currentEntry) {
+      if (currentSection && currentSection.items.length > 0) {
+        currentEntry.sections.push(currentSection);
+      }
+      currentSection = {
+        type: sectionMatch[1],
+        items: [],
+      };
+      continue;
+    }
+
+    // Match list items: - Item text
+    const itemMatch = line.match(/^- (.+)/);
+    if (itemMatch && currentSection) {
+      currentSection.items.push(itemMatch[1]);
+      continue;
+    }
+
+    // Match indented list items (sub-items): "  - Sub item"
+    const subItemMatch = line.match(/^\s{2,}- (.+)/);
+    if (subItemMatch && currentSection && currentSection.items.length > 0) {
+      // Append to last item
+      const lastIdx = currentSection.items.length - 1;
+      currentSection.items[lastIdx] += ` (${subItemMatch[1]})`;
+    }
+  }
+
+  // Don't forget the last entry
+  if (currentEntry) {
+    if (currentSection && currentSection.items.length > 0) {
+      currentEntry.sections.push(currentSection);
+    }
+    entries.push(currentEntry);
+  }
+
+  return entries;
+}
+
+function main(): void {
+  console.log('Generating changelog...');
+
+  // Check if CHANGELOG.md exists
+  if (!fs.existsSync(CHANGELOG_MD)) {
+    console.error('Error: CHANGELOG.md not found at project root');
+    process.exit(1);
+  }
+
+  // Read the markdown content
+  const content = fs.readFileSync(CHANGELOG_MD, 'utf-8');
+
+  // Parse into structured data
+  const entries = parseChangelog(content);
+
+  // Ensure src/data directory exists
+  const dataDir = path.dirname(OUTPUT_FILE);
+  if (!fs.existsSync(dataDir)) {
+    fs.mkdirSync(dataDir, { recursive: true });
+  }
+
+  // Generate the TypeScript file
+  const tsContent = `// Auto-generated from CHANGELOG.md - DO NOT EDIT DIRECTLY
+// Run 'yarn generate:changelog' to regenerate
+
+export interface ChangelogSection {
+  type: string;
+  items: string[];
+}
+
+export interface ChangelogEntry {
+  version: string;
+  date: string | null;
+  sections: ChangelogSection[];
+}
+
+export const changelog: ChangelogEntry[] = ${JSON.stringify(entries, null, 2)};
+`;
+
+  fs.writeFileSync(OUTPUT_FILE, tsContent);
+  console.log(`Generated: ${OUTPUT_FILE}`);
+  console.log(`  ${entries.length} changelog entries parsed`);
+}
+
+main();

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -2,62 +2,188 @@
 
 import { PageLayout } from '@/components/layout/PageLayout';
 import { Card } from '@/components/Card';
+import { Link } from '@/components/Link';
+import { useLanguage } from '@/context/LanguageContext';
+
+function AboutEnglish() {
+  return (
+    <>
+      <h1 className="text-3xl font-light mb-6 text-gray-900 dark:text-gray-200">
+        About msvens chess
+      </h1>
+
+      <div className="space-y-4 text-gray-600 dark:text-gray-400">
+        <p>
+          msvens chess started as a side project by an avid chess parent who frequently
+          visits result.schack.se to follow tournaments, track chess statistics, and explore
+          all the great data that schack.se provides.
+        </p>
+
+        <p>
+          The goal from the start was to offer the same functionality as result.schack.se
+          while focusing on a few key improvements:
+        </p>
+
+        <ul className="list-disc list-outside space-y-3 ml-6">
+          <li>
+            <span className="font-medium text-gray-700 dark:text-gray-300">Mobile experience.</span>{' '}
+            result.schack.se wasn&apos;t built for the mobile era, yet during tournaments a phone is
+            often all you have. msvens chess takes a mobile-first approach.
+          </li>
+          <li>
+            <span className="font-medium text-gray-700 dark:text-gray-300">Multi-lingual support.</span>{' '}
+            Many chess players and parents in Sweden aren&apos;t native Swedish speakers. Making
+            the site bilingual was a clear priority.
+          </li>
+          <li>
+            <span className="font-medium text-gray-700 dark:text-gray-300">Better filtering and search.</span>{' '}
+            With hundreds of tournaments running simultaneously across Sweden, finding the right
+            one can be challenging. The same applies within tournaments — some have multiple classes
+            and many groups, making navigation difficult.
+          </li>
+          <li>
+            <span className="font-medium text-gray-700 dark:text-gray-300">Data compatibility.</span>{' '}
+            ELO performances, scores, and other statistics should match what result.schack.se shows.
+          </li>
+        </ul>
+
+        <p>
+          The long-term hope is that this project might evolve into a more official results
+          portal for schack.se. It would also be exciting to integrate functionality from
+          the various chess districts and federations.
+        </p>
+
+        <p>
+          This project wouldn&apos;t have been possible without the great people at schack.se.
+          They&apos;ve provided excellent APIs, are incredibly helpful with questions, and are
+          always willing to accommodate requests.
+        </p>
+
+        <div className="pt-6">
+          <h2 className="text-xl font-medium mb-4 text-gray-900 dark:text-gray-200">
+            Links & Acknowledgments
+          </h2>
+          <ul className="list-disc list-inside space-y-2 ml-2">
+            <li>
+              <Link href="https://schack.se/" external>schack.se</Link>
+              {' — '}the official Swedish Chess Federation website
+            </li>
+            <li>
+              <Link href="https://resultat.schack.se/" external>resultat.schack.se</Link>
+              {' — '}the official results portal
+            </li>
+            <li>
+              <Link href="https://www.stockholmsschack.se/" external>stockholmsschack.se</Link>
+              {' — '}the Stockholm Chess Federation
+            </li>
+            <li>
+              <Link href="https://claude.ai/code" external>Claude Code</Link>
+              {' — '}made building this a bit easier :)
+            </li>
+          </ul>
+        </div>
+
+        <p className="pt-4">
+          And finally, thanks to everyone who has tested the site and provided feedback!
+        </p>
+      </div>
+    </>
+  );
+}
+
+function AboutSwedish() {
+  return (
+    <>
+      <h1 className="text-3xl font-light mb-6 text-gray-900 dark:text-gray-200">
+        Om msvens schack
+      </h1>
+
+      <div className="space-y-4 text-gray-600 dark:text-gray-400">
+        <p>
+          msvens schack började som ett sidoprojekt av en engagerad schackförälder som ofta
+          besöker result.schack.se för att följa turneringar, hålla koll på schackstatistik
+          och utforska all data som schack.se erbjuder.
+        </p>
+
+        <p>
+          Målet från början var att erbjuda samma funktionalitet som result.schack.se
+          men fokusera på några viktiga förbättringar:
+        </p>
+
+        <ul className="list-disc list-outside space-y-3 ml-6">
+          <li>
+            <span className="font-medium text-gray-700 dark:text-gray-300">Mobilupplevelse.</span>{' '}
+            result.schack.se byggdes inte för mobilens tidsålder, men under turneringar är
+            telefonen ofta det enda man har. msvens schack tar ett mobil-först-perspektiv.
+          </li>
+          <li>
+            <span className="font-medium text-gray-700 dark:text-gray-300">Flerspråkigt stöd.</span>{' '}
+            Många schackspelare och föräldrar i Sverige har inte svenska som modersmål. Att
+            göra sidan tvåspråkig var en tydlig prioritet.
+          </li>
+          <li>
+            <span className="font-medium text-gray-700 dark:text-gray-300">Bättre filtrering och sökning.</span>{' '}
+            Med hundratals turneringar som pågår samtidigt runt om i Sverige kan det vara svårt
+            att hitta rätt. Samma sak gäller inom turneringar — vissa har flera klasser och
+            många grupper, vilket gör navigering besvärlig.
+          </li>
+          <li>
+            <span className="font-medium text-gray-700 dark:text-gray-300">Datakompatibilitet.</span>{' '}
+            ELO-prestationer, poäng och annan statistik ska matcha det som result.schack.se visar.
+          </li>
+        </ul>
+
+        <p>
+          Den långsiktiga förhoppningen är att detta projekt kan utvecklas till en mer
+          officiell resultatportal för schack.se. Det skulle också vara spännande att
+          integrera funktionalitet från de olika schackdistrikten och förbunden.
+        </p>
+
+        <p>
+          Detta projekt hade inte varit möjligt utan de fantastiska människorna på schack.se.
+          De har tillhandahållit utmärkta API:er, är otroligt hjälpsamma med frågor och är
+          alltid villiga att tillmötesgå önskemål.
+        </p>
+
+        <div className="pt-6">
+          <h2 className="text-xl font-medium mb-4 text-gray-900 dark:text-gray-200">
+            Länkar & Tack
+          </h2>
+          <ul className="list-disc list-inside space-y-2 ml-2">
+            <li>
+              <Link href="https://schack.se/" external>schack.se</Link>
+              {' — '}Svenska Schackförbundets officiella webbplats
+            </li>
+            <li>
+              <Link href="https://resultat.schack.se/" external>resultat.schack.se</Link>
+              {' — '}den officiella resultatportalen
+            </li>
+            <li>
+              <Link href="https://www.stockholmsschack.se/" external>stockholmsschack.se</Link>
+              {' — '}Stockholms Schackförbund
+            </li>
+            <li>
+              <Link href="https://claude.ai/code" external>Claude Code</Link>
+              {' — '}gjorde byggandet av detta lite enklare :)
+            </li>
+          </ul>
+        </div>
+
+        <p className="pt-4">
+          Och slutligen, tack till alla som har testat sidan och gett feedback!
+        </p>
+      </div>
+    </>
+  );
+}
 
 export default function AboutPage() {
+  const { language } = useLanguage();
+
   return (
     <PageLayout maxWidth="4xl">
       <Card padding="lg" border={false} className="pt-0">
-        <h1 className="text-3xl font-light mb-6 text-gray-900 dark:text-gray-200">
-          Om Stockholmschack
-        </h1>
-
-        <div className="space-y-4 text-gray-600 dark:text-gray-400">
-          <p>
-            Välkommen till Stockholmschacks portal, din centrala källa för schackturneringar,
-            spelarinformation och resultat från Stockholms schackvärld.
-          </p>
-
-          <p>
-            Denna plattform tillhandahåller omfattande turneringsresultat, spelarstatistik och
-            kommande schackevenemang i Stockholmsregionen. Oavsett om du är en tävlingsspelare
-            som följer dina resultat eller en schackentusiast som följer lokala turneringar,
-            hittar du all information du behöver här.
-          </p>
-
-          <p>
-            Vår databas innehåller detaljerad turneringshistorik, spelarratings och
-            rondresultat från klubbar i hela Stockholm. Vi är dedikerade till att göra
-            schackinformation tillgänglig och lätt att navigera för alla i gemenskapen.
-          </p>
-
-          <div className="pt-4">
-            <h2 className="text-xl font-semibold mb-3 text-gray-900 dark:text-gray-200">
-              Relaterade länkar
-            </h2>
-            <ul className="list-disc list-inside space-y-2">
-              <li>
-                <a
-                  href="https://schack.se/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-blue-600 dark:text-blue-400 hover:underline"
-                >
-                  Svenska Schackförbundet
-                </a>
-              </li>
-              <li>
-                <a
-                  href="https://www.stockholmsschack.se/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-blue-600 dark:text-blue-400 hover:underline"
-                >
-                  Stockholms Schackförbund
-                </a>
-              </li>
-            </ul>
-          </div>
-        </div>
+        {language === 'en' ? <AboutEnglish /> : <AboutSwedish />}
       </Card>
     </PageLayout>
   );

--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { PageLayout } from '@/components/layout/PageLayout';
+import { Card } from '@/components/Card';
+import { changelog, ChangelogEntry, ChangelogSection } from '@/data/changelog';
+
+function SectionBadge({ type }: { type: string }) {
+  const colors: Record<string, string> = {
+    Added: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+    Changed: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+    Fixed: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
+    Removed: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
+    Infrastructure: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400',
+  };
+
+  const colorClass = colors[type] || 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-400';
+
+  return (
+    <span className={`inline-block px-2 py-0.5 text-xs font-medium rounded ${colorClass}`}>
+      {type}
+    </span>
+  );
+}
+
+function ChangelogSectionView({ section }: { section: ChangelogSection }) {
+  return (
+    <div className="mb-4">
+      <SectionBadge type={section.type} />
+      <ul className="mt-2 space-y-1 text-gray-600 dark:text-gray-400">
+        {section.items.map((item, idx) => (
+          <li key={idx} className="flex items-start">
+            <span className="mr-2 text-gray-400">•</span>
+            <span>{item}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ChangelogEntryView({ entry }: { entry: ChangelogEntry }) {
+  return (
+    <div className="mb-8 pb-8 border-b border-gray-200 dark:border-gray-700 last:border-0">
+      <div className="flex items-baseline gap-3 mb-4">
+        <h2 className="text-xl font-medium text-gray-900 dark:text-gray-200">
+          {entry.version === 'Unreleased' ? 'Unreleased' : `v${entry.version}`}
+        </h2>
+        {entry.date && (
+          <span className="text-sm text-gray-500 dark:text-gray-500">
+            {entry.date}
+          </span>
+        )}
+      </div>
+      {entry.sections.map((section, idx) => (
+        <ChangelogSectionView key={idx} section={section} />
+      ))}
+    </div>
+  );
+}
+
+export default function ChangelogPage() {
+  return (
+    <PageLayout maxWidth="4xl">
+      <Card padding="lg" border={false} className="pt-0">
+        <h1 className="text-3xl font-light mb-2 text-gray-900 dark:text-gray-200">
+          Changelog
+        </h1>
+        <p className="text-gray-600 dark:text-gray-400 mb-8">
+          All notable changes to msvens chess.
+        </p>
+
+        {changelog.map((entry, idx) => (
+          <ChangelogEntryView key={idx} entry={entry} />
+        ))}
+      </Card>
+    </PageLayout>
+  );
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import { useState, FormEvent } from 'react';
+import { PageLayout } from '@/components/layout/PageLayout';
+import { PageTitle } from '@/components/PageTitle';
+import { Card } from '@/components/Card';
+import { useLanguage } from '@/context/LanguageContext';
+import { getTranslation } from '@/lib/translations';
+
+// Formspree endpoint - set this in your .env.local file
+// NEXT_PUBLIC_FORMSPREE_ENDPOINT=https://formspree.io/f/your-form-id
+const FORMSPREE_ENDPOINT = process.env.NEXT_PUBLIC_FORMSPREE_ENDPOINT || '';
+
+type FormStatus = 'idle' | 'sending' | 'success' | 'error';
+
+export default function ContactPage() {
+  const { language } = useLanguage();
+  const t = getTranslation(language);
+
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+  const [status, setStatus] = useState<FormStatus>('idle');
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+
+    if (!FORMSPREE_ENDPOINT) {
+      console.error('Formspree endpoint not configured');
+      setStatus('error');
+      return;
+    }
+
+    setStatus('sending');
+
+    try {
+      const response = await fetch(FORMSPREE_ENDPOINT, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ email, message }),
+      });
+
+      if (response.ok) {
+        setStatus('success');
+        setEmail('');
+        setMessage('');
+      } else {
+        setStatus('error');
+      }
+    } catch {
+      setStatus('error');
+    }
+  };
+
+  const isConfigured = !!FORMSPREE_ENDPOINT;
+
+  return (
+    <PageLayout maxWidth="3xl">
+      <PageTitle
+        title={t.pages.contact.title}
+        subtitle={t.pages.contact.subtitle}
+      />
+
+      <Card padding="lg" border={false}>
+        {!isConfigured ? (
+          <div className="p-6 text-center">
+            <p className="text-gray-600 dark:text-gray-400">
+              Under construction. Check back soon!
+            </p>
+          </div>
+        ) : status === 'success' ? (
+          <div className="p-6 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg text-center">
+            <p className="text-green-800 dark:text-green-200">
+              {t.pages.contact.form.success}
+            </p>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div>
+              <label
+                htmlFor="email"
+                className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
+              >
+                {t.pages.contact.form.email}
+              </label>
+              <input
+                type="email"
+                id="email"
+                name="email"
+                required
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder={t.pages.contact.form.emailPlaceholder}
+                className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg
+                  bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100
+                  focus:ring-2 focus:ring-blue-500 focus:border-transparent
+                  placeholder-gray-400 dark:placeholder-gray-500"
+                disabled={status === 'sending'}
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor="message"
+                className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
+              >
+                {t.pages.contact.form.message}
+              </label>
+              <textarea
+                id="message"
+                name="message"
+                required
+                rows={6}
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
+                placeholder={t.pages.contact.form.messagePlaceholder}
+                className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg
+                  bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100
+                  focus:ring-2 focus:ring-blue-500 focus:border-transparent
+                  placeholder-gray-400 dark:placeholder-gray-500 resize-none"
+                disabled={status === 'sending'}
+              />
+            </div>
+
+            {status === 'error' && (
+              <div className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
+                <p className="text-red-800 dark:text-red-200 text-sm">
+                  {t.pages.contact.form.error}
+                </p>
+              </div>
+            )}
+
+            <button
+              type="submit"
+              disabled={status === 'sending' || !isConfigured}
+              className="w-full sm:w-auto px-6 py-2 bg-blue-600 hover:bg-blue-700
+                disabled:bg-gray-400 disabled:cursor-not-allowed
+                text-white font-medium rounded-lg transition-colors
+                focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            >
+              {status === 'sending'
+                ? t.pages.contact.form.sending
+                : t.pages.contact.form.submit}
+            </button>
+          </form>
+        )}
+      </Card>
+    </PageLayout>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,8 +18,8 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Stockholm Chess Reimagined",
-  description: "Modern chess tournament portal for Stockholm, Sweden. Find upcoming tournaments, view results, and stay informed about chess events.",
+  title: "msvens chess",
+  description: "Modern chess tournament portal for Sweden. Find upcoming tournaments, view results, and explore player ratings and history.",
 };
 
 export default function RootLayout({

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -18,7 +18,7 @@ function FooterLink({ href, children, external = false }: FooterLinkProps) {
   return (
     <Link
       href={href}
-      className="uppercase mx-2 text-[10px] text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors"
+      className="uppercase mx-2 text-xs sm:text-sm font-light text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors"
       {...externalProps}
     >
       {children}
@@ -32,10 +32,10 @@ export function Footer() {
 
   return (
     <footer className="w-full">
-      <div className="max-w-7xl mx-auto px-4 pt-6 pb-2 flex justify-center items-center">
+      <div className="max-w-7xl mx-auto px-4 pt-6 pb-6 flex justify-center items-center">
         <FooterLink href="/about">{t.footer.navigation.about}</FooterLink>
-        <FooterLink href="https://schack.se/" external>schack.se</FooterLink>
-        <FooterLink href="https://www.stockholmsschack.se/" external>stockholmsschack.se</FooterLink>
+        <FooterLink href="/contact">{t.footer.navigation.contact}</FooterLink>
+        <FooterLink href="/changelog">{t.footer.navigation.changelog}</FooterLink>
       </div>
     </footer>
   );

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -59,8 +59,8 @@ export default function Navbar() {
           {/* App Name - Left aligned (matching mphotos-ui exactly) */}
           <div className="flex items-center flex-shrink-0 pl-1">
             <Link href="/" className="text-base font-light leading-tight tracking-widest uppercase text-gray-900 dark:text-gray-200">
-              <span className="block">Stockholm</span>
-              <span className="block">Chess</span>
+              <span className="block">msvens</span>
+              <span className="block">chess</span>
             </Link>
           </div>
           

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -1,0 +1,149 @@
+// Auto-generated from CHANGELOG.md - DO NOT EDIT DIRECTLY
+// Run 'yarn generate:changelog' to regenerate
+
+export interface ChangelogSection {
+  type: string;
+  items: string[];
+}
+
+export interface ChangelogEntry {
+  version: string;
+  date: string | null;
+  sections: ChangelogSection[];
+}
+
+export const changelog: ChangelogEntry[] = [
+  {
+    "version": "Unreleased",
+    "date": null,
+    "sections": [
+      {
+        "type": "Added",
+        "items": [
+          "Contact page for user feedback (Formspree integration pending)",
+          "Changelog page with structured version history",
+          "Changelog generation script (`yarn generate:changelog`)",
+          "Bilingual About page with project background and acknowledgments"
+        ]
+      },
+      {
+        "type": "Changed",
+        "items": [
+          "Rebranded from \"Stockholm Chess\" to \"msvens chess\"",
+          "Updated site metadata and descriptions to focus on Sweden-wide coverage",
+          "Footer navigation now links to About, Contact, and Changelog",
+          "Footer styling: larger text on desktop, increased padding"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "0.4.0",
+    "date": "2025-01-20",
+    "sections": [
+      {
+        "type": "Added",
+        "items": [
+          "Tournament filters for calendar and results pages (category, type, status, district)",
+          "Comprehensive game result handling for all point systems",
+          "PageTitle component for consistent page headers"
+        ]
+      },
+      {
+        "type": "Fixed",
+        "items": [
+          "Mobile navbar now shows Results and Players icons",
+          "Deduplicated tournament search results"
+        ]
+      },
+      {
+        "type": "Changed",
+        "items": [
+          "Improved translation system with common section for shared strings"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "0.3.0",
+    "date": "2025-01-15",
+    "sections": [
+      {
+        "type": "Added",
+        "items": [
+          "Organizations page with clubs and districts browser",
+          "Club rating lists with filtering by rating type and member category",
+          "Opponents statistics page with progressive loading",
+          "Batch API methods for efficient multi-ID fetching",
+          "Player rating history with batched requests"
+        ]
+      },
+      {
+        "type": "Changed",
+        "items": [
+          "Unified player page tournament data from games",
+          "Optimized imports with centralized @/lib/api exports",
+          "Enhanced rating display on tournament result pages"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "0.2.0",
+    "date": "2025-01-10",
+    "sections": [
+      {
+        "type": "Added",
+        "items": [
+          "Team tournament support with expandable match details",
+          "Club-based player assignments for team tournaments",
+          "W.O. (walkover) handling for forfeited games",
+          "Results page with date range and text search",
+          "Tournament timestamp column showing last update"
+        ]
+      },
+      {
+        "type": "Changed",
+        "items": [
+          "Centralized API environment configuration",
+          "Simplified player search with recent players in localStorage"
+        ]
+      },
+      {
+        "type": "Fixed",
+        "items": [
+          "Team tournament result display improvements"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "0.1.0",
+    "date": "2025-01-05",
+    "sections": [
+      {
+        "type": "Added",
+        "items": [
+          "Initial release of msvens chess (then Stockholm Chess)",
+          "Tournament calendar with upcoming events",
+          "Tournament results browser",
+          "Player search by name or member ID",
+          "Player profiles with: (ELO ratings (standard, rapid, blitz)) (LASK ratings) (Tournament history with tabbed navigation) (ELO rating history chart) (Player photos from SSF)",
+          "Round-by-round results for individual tournaments",
+          "Dark/light theme support",
+          "English and Swedish language support",
+          "Mobile-responsive design"
+        ]
+      },
+      {
+        "type": "Infrastructure",
+        "items": [
+          "Next.js 15 with App Router",
+          "Tailwind CSS for styling",
+          "API service layer for SSF tournament data",
+          "Jest testing setup"
+        ]
+      }
+    ]
+  }
+];

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -2,10 +2,6 @@ import { Language } from '@/context/LanguageContext';
 
 export interface Translations {
   navbar: {
-    brand: {
-      line1: string;
-      line2: string;
-    };
     navigation: {
       upcomingEvents: string;
       calendar: string;
@@ -24,11 +20,9 @@ export interface Translations {
       subtitle: string;
     };
     navigation: {
-      events: string;
-      calendar: string;
-      results: string;
-      players: string;
       about: string;
+      contact: string;
+      changelog: string;
     };
     external: {
       poweredBy: string;
@@ -134,6 +128,20 @@ export interface Translations {
     };
   };
   pages: {
+    contact: {
+      title: string;
+      subtitle: string;
+      form: {
+        email: string;
+        emailPlaceholder: string;
+        message: string;
+        messagePlaceholder: string;
+        submit: string;
+        sending: string;
+        success: string;
+        error: string;
+      };
+    };
     events: {
       title: string;
       subtitle: string;
@@ -398,10 +406,6 @@ export interface Translations {
 const translations: Record<Language, Translations> = {
   en: {
     navbar: {
-      brand: {
-        line1: 'Stockholm',
-        line2: 'Chess',
-      },
       navigation: {
         upcomingEvents: 'Upcoming Events',
         calendar: 'Calendar',
@@ -416,15 +420,13 @@ const translations: Record<Language, Translations> = {
     },
     footer: {
       projectInfo: {
-        title: 'Stockholm Chess Reimagined',
-        subtitle: 'Modernizing chess tournament discovery in Stockholm',
+        title: 'msvens chess',
+        subtitle: 'Modernizing chess tournament discovery in Sweden',
       },
       navigation: {
-        events: 'Events',
-        calendar: 'Calendar',
-        results: 'Results',
-        players: 'Players',
         about: 'About',
+        contact: 'Contact',
+        changelog: 'Changelog',
       },
       external: {
         poweredBy: 'Powered by',
@@ -433,13 +435,13 @@ const translations: Record<Language, Translations> = {
     home: {
       hero: {
         title: 'Welcome to',
-        titleHighlight: 'Stockholm Chess',
-        subtitle: 'Discover upcoming tournaments, view results, and stay connected with the chess community in Stockholm.',
+        titleHighlight: 'msvens chess',
+        subtitle: 'Discover upcoming tournaments, view results, and stay connected with the chess community in Sweden.',
       },
       cards: {
         upcomingEvents: {
           title: 'Upcoming Events',
-          description: 'Find the latest tournaments and events happening in Stockholm.',
+          description: 'Find the latest tournaments and events happening in Sweden.',
           link: 'Browse Events',
         },
         calendar: {
@@ -459,9 +461,9 @@ const translations: Record<Language, Translations> = {
         },
       },
       about: {
-        title: 'About Stockholm Chess Reimagined',
-        paragraph1: 'This modern chess portal complements the existing Stockholm Schackförbund and Svenska Schackförbundet websites, focusing specifically on tournament discovery and management. We\'re building a user-friendly interface that makes it easy for chess players of all levels to find and participate in chess events across Stockholm.',
-        paragraph2: 'Whether you\'re a beginner looking for your first tournament or an experienced player tracking results, Stockholm Chess Reimagined provides the tools you need to stay connected with the local chess community.',
+        title: 'About msvens chess',
+        paragraph1: 'This modern chess portal complements the existing Svenska Schackförbundet website, focusing specifically on tournament discovery and management. We\'re building a user-friendly interface that makes it easy for chess players of all levels to find and participate in chess events across Sweden.',
+        paragraph2: 'Whether you\'re a beginner looking for your first tournament or an experienced player tracking results, msvens chess provides the tools you need to stay connected with the chess community.',
       },
     },
     common: {
@@ -530,9 +532,23 @@ const translations: Record<Language, Translations> = {
       },
     },
     pages: {
+      contact: {
+        title: 'Feedback',
+        subtitle: 'Have a suggestion or found a bug? Let us know!',
+        form: {
+          email: 'Your Email',
+          emailPlaceholder: 'name@example.com',
+          message: 'Message',
+          messagePlaceholder: 'Share your thoughts, suggestions, or report an issue...',
+          submit: 'Send Feedback',
+          sending: 'Sending...',
+          success: 'Thank you for your feedback! We\'ll get back to you if needed.',
+          error: 'Something went wrong. Please try again later.',
+        },
+      },
       events: {
         title: 'Upcoming Events',
-        subtitle: 'Discover the latest chess tournaments and events happening in Stockholm.',
+        subtitle: 'Discover the latest chess tournaments and events happening in Sweden.',
         placeholder: 'Event listings coming soon. This page will display upcoming tournaments with details, dates, and registration information.',
       },
       calendar: {
@@ -792,10 +808,6 @@ const translations: Record<Language, Translations> = {
   },
   sv: {
     navbar: {
-      brand: {
-        line1: 'Stockholm',
-        line2: 'Schack',
-      },
       navigation: {
         upcomingEvents: 'Kommande Evenemang',
         calendar: 'Kalender',
@@ -810,15 +822,13 @@ const translations: Record<Language, Translations> = {
     },
     footer: {
       projectInfo: {
-        title: 'Stockholm Schack Omskapat',
-        subtitle: 'Moderniserar schackturneringar i Stockholm',
+        title: 'msvens schack',
+        subtitle: 'Moderniserar schackturneringar i Sverige',
       },
       navigation: {
-        events: 'Evenemang',
-        calendar: 'Kalender',
-        results: 'Resultat',
-        players: 'Spelare',
         about: 'Om',
+        contact: 'Kontakt',
+        changelog: 'Ändringslogg',
       },
       external: {
         poweredBy: 'Drivs av',
@@ -827,13 +837,13 @@ const translations: Record<Language, Translations> = {
     home: {
       hero: {
         title: 'Välkommen till',
-        titleHighlight: 'Stockholm Schack',
-        subtitle: 'Upptäck kommande turneringar, se resultat och håll dig uppdaterad med schackgemenskapen i Stockholm.',
+        titleHighlight: 'msvens schack',
+        subtitle: 'Upptäck kommande turneringar, se resultat och håll dig uppdaterad med schackgemenskapen i Sverige.',
       },
       cards: {
         upcomingEvents: {
           title: 'Kommande Evenemang',
-          description: 'Hitta de senaste turneringarna och evenemangen som händer i Stockholm.',
+          description: 'Hitta de senaste turneringarna och evenemangen som händer i Sverige.',
           link: 'Bläddra Evenemang',
         },
         calendar: {
@@ -853,9 +863,9 @@ const translations: Record<Language, Translations> = {
         },
       },
       about: {
-        title: 'Om Stockholm Schack Omskapat',
-        paragraph1: 'Denna moderna schackportal kompletterar de befintliga webbplatserna för Stockholm Schackförbund och Svenska Schackförbundet, med fokus specifikt på turneringsupptäckt och hantering. Vi bygger ett användarvänligt gränssnitt som gör det enkelt för schackspelare på alla nivåer att hitta och delta i schackevenemang över hela Stockholm.',
-        paragraph2: 'Oavsett om du är en nybörjare som letar efter din första turnering eller en erfaren spelare som spårar resultat, ger Stockholm Schack Omskapat dig verktygen du behöver för att hålla dig uppdaterad med den lokala schackgemenskapen.',
+        title: 'Om msvens schack',
+        paragraph1: 'Denna moderna schackportal kompletterar Svenska Schackförbundets webbplats, med fokus specifikt på turneringsupptäckt och hantering. Vi bygger ett användarvänligt gränssnitt som gör det enkelt för schackspelare på alla nivåer att hitta och delta i schackevenemang över hela Sverige.',
+        paragraph2: 'Oavsett om du är en nybörjare som letar efter din första turnering eller en erfaren spelare som spårar resultat, ger msvens schack dig verktygen du behöver för att hålla dig uppdaterad med schackgemenskapen.',
       },
     },
     common: {
@@ -924,9 +934,23 @@ const translations: Record<Language, Translations> = {
       },
     },
     pages: {
+      contact: {
+        title: 'Feedback',
+        subtitle: 'Har du ett förslag eller hittat en bugg? Hör av dig!',
+        form: {
+          email: 'Din e-post',
+          emailPlaceholder: 'namn@example.com',
+          message: 'Meddelande',
+          messagePlaceholder: 'Dela dina tankar, förslag eller rapportera ett problem...',
+          submit: 'Skicka feedback',
+          sending: 'Skickar...',
+          success: 'Tack för din feedback! Vi återkommer om det behövs.',
+          error: 'Något gick fel. Försök igen senare.',
+        },
+      },
       events: {
         title: 'Kommande Evenemang',
-        subtitle: 'Upptäck de senaste schackturneringarna och evenemangen som händer i Stockholm.',
+        subtitle: 'Upptäck de senaste schackturneringarna och evenemangen som händer i Sverige.',
         placeholder: 'Evenemangslistor kommer snart. Denna sida kommer att visa kommande turneringar med detaljer, datum och registreringsinformation.',
       },
       calendar: {


### PR DESCRIPTION
## Summary
- Rebrand from "Stockholm Chess" to "msvens chess" with hardcoded brand name
- Add bilingual About page with project background and acknowledgments
- Add Contact page with Formspree integration (pending configuration)
- Add Changelog page with structured version history and build-time generation
- Update footer navigation to link to About, Contact, and Changelog
- Update site metadata and descriptions for Sweden-wide coverage

## Changes
- **New pages**: `/about`, `/contact`, `/changelog`
- **Build script**: `yarn generate:changelog` parses CHANGELOG.md into TypeScript
- **Footer**: Links to internal pages instead of external sites
- **Navbar**: Hardcoded "msvens chess" brand name

## Test plan
- [ ] Verify About page displays correctly in both English and Swedish
- [ ] Verify Contact page shows "Under construction" (Formspree not configured)
- [ ] Verify Changelog page renders all versions with color-coded sections
- [ ] Verify footer links navigate to correct pages
- [ ] Verify `yarn build` succeeds
- [ ] Test language switching on all new pages