### PR TITLE
feat: restructure organizations with districts, clubs, and SSF pages

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,0 +1,66 @@
+# Commit Command
+
+Validate and commit changes: $ARGUMENTS
+
+## Arguments
+
+- `test` or `-t`: Also run `yarn test` after build
+- No arguments: Just tsc, build, and commit
+
+## Steps
+
+1. **Check for changes**
+   - Run `git status` to see what's changed
+   - If no changes, inform user and stop
+
+2. **Type check**
+   - Run `yarn tsc --noEmit`
+   - If fails: Stop and report errors
+
+3. **Build**
+   - Run `yarn build`
+   - If fails: Stop and report errors
+
+4. **Test (if requested)**
+   - If `test` or `-t` argument provided, run `yarn test`
+   - If fails: Stop and report errors
+
+5. **Analyze changes for commit**
+   - Run `git diff --staged` and `git diff` to understand changes
+   - Run `git status` to see all modified and untracked files
+   - Run `git log --oneline -5` to see recent commit style
+
+6. **Stage changes**
+   - **Default to ONE commit** with all changes (user often works on multiple things)
+   - Only suggest splitting into multiple commits if changes are truly large AND distinct
+   - **Ensure nothing is forgotten** - all modified files should be committed
+   - For untracked files:
+     - Include project-related files (new components, tests, configs)
+     - **Ask about suspicious/unrelated files** (drafts, personal notes, random .txt files)
+     - Never include sensitive files (.env, credentials, secrets)
+   - Prefer staging specific files by name over `git add -A`
+
+7. **Commit**
+   - Generate clear, concise commit message
+   - Use imperative mood ("Add feature" not "Added feature")
+   - Focus on what and why, not how
+   - **NO Claude attribution or co-authored-by lines**
+
+8. **Report success**
+   - Show commit hash
+   - Show summary of what was committed
+
+## Important
+
+- **Abort immediately** if any validation step fails (tsc, build, test)
+- **Never** add co-authored-by or Claude attribution to commits
+- **Never** commit sensitive files (.env, credentials, etc.)
+- **Never** push automatically - user will push when ready
+
+## Example usage
+
+```
+/commit              # Validate and commit
+/commit test         # Also run tests
+/commit -t           # Also run tests (short form)
+```

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -5,30 +5,62 @@ Create a new release with version: $ARGUMENTS
 ## Steps
 
 1. **Validate version argument**
-   - If no version provided, show current [Unreleased] changes from CHANGELOG.md and ask for version number
+   - If no version provided, show current [Unreleased] section and ask for version number
    - Version should follow semver format (e.g., 0.5.1, 1.0.0)
 
-2. **Update CHANGELOG.md**
+2. **Generate changelog from commits**
+   - Find the last release tag: `git describe --tags --abbrev=0`
+   - Get all commits since that tag: `git log <last-tag>..HEAD --oneline`
+   - Analyze commits and generate meaningful user-facing changelog entries
+   - Group by category:
+     - **Added** - New features
+     - **Changed** - Changes to existing functionality
+     - **Fixed** - Bug fixes
+     - **Removed** - Removed features
+   - Filter out noise (internal refactors, typo fixes, version bumps, etc.)
+   - Summarize related commits into single entries (e.g., 5 pagination commits → one entry)
+   - Add entries to the [Unreleased] section in CHANGELOG.md
+
+3. **Update CHANGELOG.md version header**
    - Change `## [Unreleased]` to `## [VERSION] - YYYY-MM-DD` (today's date)
    - Add new empty `## [Unreleased]` section above it with a `---` separator
 
-3. **Regenerate and build**
-   - Run `yarn build` (this includes `yarn generate:changelog` via prebuild hook)
-   - If build fails, stop and report the error
+4. **Validate**
+   - Run `yarn tsc --noEmit`
+   - If fails: Stop and report errors
 
-4. **Commit and tag**
+5. **Build**
+   - Run `yarn build` (includes `yarn generate:changelog` via prebuild hook)
+   - If fails: Stop and report errors
+
+6. **Commit and tag**
    - Stage: `git add CHANGELOG.md src/data/changelog.ts`
    - Commit: `git commit -m "release: vVERSION"`
    - Tag: `git tag vVERSION`
+   - **NO Claude attribution**
 
-5. **Push**
+7. **Push**
    - Push commit: `git push`
    - Push tag: `git push --tags`
 
-6. **Report success**
+8. **Report success**
    - Show the commit hash
    - Show the tag name
+   - Show changelog entries that were added
    - Provide link to GitHub releases page
+
+## Changelog Guidelines
+
+When generating changelog entries:
+- Focus on **user-facing changes** only
+- Use clear, non-technical language where possible
+- One line per feature/fix (can have sub-bullets if complex)
+- Skip:
+  - Internal refactoring
+  - Code style changes
+  - Dependency updates (unless user-facing)
+  - Typo fixes in code
+  - Build/config changes (unless user-facing)
 
 ## Example usage
 

--- a/src/app/organizations/clubs/[id]/page.tsx
+++ b/src/app/organizations/clubs/[id]/page.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useParams } from 'next/navigation';
+import { useLanguage } from '@/context/LanguageContext';
+import { useOrganizations } from '@/context/OrganizationsContext';
+import { PageLayout } from '@/components/layout/PageLayout';
+import { RatingFilters, RatingFiltersValue, getDefaultRatingFilters } from '@/components/organizations/RatingFilters';
+import { RatingTable } from '@/components/RatingTable';
+import { Link } from '@/components/Link';
+import { TextDisplay } from '@/components/TextDisplay';
+import { getTranslation } from '@/lib/translations';
+import { RatingsService } from '@/lib/api/services/ratings';
+import type { PlayerInfoDto, ClubDTO } from '@/lib/api/types';
+
+export default function ClubDetailPage() {
+  const params = useParams();
+  const { language } = useLanguage();
+  const { getClub, getDistrict, loading: orgsLoading } = useOrganizations();
+  const t = getTranslation(language);
+
+  const clubId = params.id ? parseInt(params.id as string) : null;
+
+  const [filters, setFilters] = useState<RatingFiltersValue>(getDefaultRatingFilters);
+  const [ratingData, setRatingData] = useState<PlayerInfoDto[]>([]);
+  const [loadingRatings, setLoadingRatings] = useState(true);
+
+  // Get club info
+  const club: ClubDTO | undefined = clubId ? getClub(clubId) : undefined;
+
+  // Get parent district info
+  const parentDistrictId = club?.districts?.find(d => d.active === 1)?.districtid;
+  const parentDistrict = parentDistrictId ? getDistrict(parentDistrictId) : undefined;
+
+  // Format school club as Yes/No
+  const isSchoolClub = club?.schoolClub === 1 ? t.pages.organizations.yes : t.pages.organizations.no;
+
+  // Fetch rating list when club or filters change
+  useEffect(() => {
+    if (!clubId) return;
+
+    const fetchRatings = async () => {
+      setLoadingRatings(true);
+      try {
+        const ratingsService = new RatingsService();
+        const response = await ratingsService.getClubRatingList(
+          clubId,
+          filters.ratingDate,
+          filters.ratingType,
+          filters.memberType
+        );
+
+        if (response.data) {
+          setRatingData(response.data);
+        } else {
+          setRatingData([]);
+        }
+      } catch (error) {
+        console.error('Failed to load ratings:', error);
+        setRatingData([]);
+      } finally {
+        setLoadingRatings(false);
+      }
+    };
+
+    fetchRatings();
+  }, [clubId, filters]);
+
+  if (!clubId) {
+    return (
+      <PageLayout maxWidth="4xl">
+        <div className="text-center text-gray-600 dark:text-gray-400">
+          Club not found
+        </div>
+      </PageLayout>
+    );
+  }
+
+  if (orgsLoading) {
+    return (
+      <PageLayout maxWidth="4xl">
+        <div className="text-center text-gray-600 dark:text-gray-400">
+          {t.pages.organizations.loading}
+        </div>
+      </PageLayout>
+    );
+  }
+
+  if (!club) {
+    return (
+      <PageLayout maxWidth="4xl">
+        <div className="text-center text-gray-600 dark:text-gray-400">
+          Club not found
+        </div>
+      </PageLayout>
+    );
+  }
+
+  return (
+    <PageLayout maxWidth="4xl">
+      <div className="space-y-6">
+        {/* Club header */}
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-200">
+            {club.name}
+          </h1>
+          {parentDistrict && (
+            <div className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+              {t.pages.organizations.clubs.district}:{' '}
+              <Link href={`/organizations/districts/${parentDistrict.id}`} color="blue">
+                {parentDistrict.name}
+              </Link>
+            </div>
+          )}
+        </div>
+
+        {/* Club info grid */}
+        <div className="grid grid-cols-2 gap-4 text-sm">
+          <InfoField
+            label={t.pages.organizations.street}
+            value={club.street || '-'}
+          />
+          <InfoField
+            label={t.pages.organizations.website}
+            value={
+              club.url ? (
+                <a
+                  href={club.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 dark:text-blue-400 hover:underline"
+                >
+                  {club.url}
+                </a>
+              ) : '-'
+            }
+          />
+          <InfoField
+            label={t.pages.organizations.city}
+            value={club.city || '-'}
+          />
+          <InfoField
+            label={t.pages.organizations.email}
+            value={club.email || '-'}
+          />
+          <InfoField
+            label={t.pages.organizations.schoolClub}
+            value={isSchoolClub}
+          />
+        </div>
+
+        {/* Club description */}
+        {club.vbdescr && (
+          <TextDisplay
+            text={club.vbdescr}
+            maxLines={2}
+            className="text-sm"
+          />
+        )}
+
+        {/* Rating List Section */}
+        <div className="space-y-4 mt-8">
+          <h3 className="text-xl font-bold text-gray-900 dark:text-gray-200">
+            {t.pages.organizations.ratingList.title}
+          </h3>
+
+          <RatingFilters
+            value={filters}
+            onChange={setFilters}
+            t={t}
+          />
+
+          <RatingTable
+            players={ratingData}
+            ratingType={filters.ratingType}
+            loading={loadingRatings}
+            t={t}
+          />
+        </div>
+      </div>
+    </PageLayout>
+  );
+}
+
+// Helper component for displaying labeled fields
+function InfoField({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div>
+      <span className="font-semibold text-gray-700 dark:text-gray-300">{label}:</span>{' '}
+      <span className="text-gray-600 dark:text-gray-400">{value}</span>
+    </div>
+  );
+}

--- a/src/app/organizations/clubs/page.tsx
+++ b/src/app/organizations/clubs/page.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useRouter } from 'next/navigation';
+import { useLanguage } from '@/context/LanguageContext';
+import { useOrganizations } from '@/context/OrganizationsContext';
+import { PageLayout } from '@/components/layout/PageLayout';
+import { PageTitle } from '@/components/PageTitle';
+import { SearchableSelectableList, SearchableSelectableListItem } from '@/components/SearchableSelectableList';
+import { Link } from '@/components/Link';
+import { getTranslation } from '@/lib/translations';
+
+export default function ClubsSearchPage() {
+  const router = useRouter();
+  const { language } = useLanguage();
+  const { getAllClubs, loading, error } = useOrganizations();
+  const t = getTranslation(language);
+
+  // Get all active clubs with rating players
+  const clubs = useMemo(() => {
+    return getAllClubs({ activeOnly: true, hasRatingPlayersOnly: true });
+  }, [getAllClubs]);
+
+  // Convert clubs to searchable items
+  const clubItems: SearchableSelectableListItem[] = useMemo(() => {
+    return clubs.map(club => ({
+      id: club.id,
+      label: club.name,
+      subtitle: club.city || undefined,
+    }));
+  }, [clubs]);
+
+  const handleClubSelect = (id: string | number) => {
+    router.push(`/organizations/clubs/${id}`);
+  };
+
+  if (loading) {
+    return (
+      <PageLayout maxWidth="4xl">
+        <div className="text-center text-gray-600 dark:text-gray-400">
+          {t.pages.organizations.loading}
+        </div>
+      </PageLayout>
+    );
+  }
+
+  if (error) {
+    return (
+      <PageLayout maxWidth="4xl">
+        <div className="text-center text-red-600 dark:text-red-400">
+          {error}
+        </div>
+      </PageLayout>
+    );
+  }
+
+  return (
+    <PageLayout maxWidth="4xl">
+      <div className="space-y-6">
+        <PageTitle
+          title={t.pages.organizations.clubs.title}
+          subtitle={t.pages.organizations.clubs.subtitle}
+        />
+
+        {/* Club search */}
+        <div className="max-w-md">
+          <SearchableSelectableList
+            items={clubItems}
+            selectedId={null}
+            onSelect={handleClubSelect}
+            placeholder={t.pages.organizations.clubs.searchPlaceholder}
+          />
+        </div>
+
+        {/* Stats */}
+        <div className="text-sm text-gray-600 dark:text-gray-400">
+          {clubs.length} {t.pages.organizations.clubs.activeClubs}
+        </div>
+
+        {/* Browse by district link */}
+        <div className="text-sm">
+          <Link href="/organizations/districts" color="blue">
+            {t.pages.organizations.clubs.browseByDistrict}
+          </Link>
+        </div>
+      </div>
+    </PageLayout>
+  );
+}

--- a/src/app/organizations/districts/[id]/page.tsx
+++ b/src/app/organizations/districts/[id]/page.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useParams } from 'next/navigation';
+import { useLanguage } from '@/context/LanguageContext';
+import { useOrganizations } from '@/context/OrganizationsContext';
+import { PageTitle } from '@/components/PageTitle';
+import { DistrictSelector } from '@/components/organizations/DistrictSelector';
+import { RatingFilters, RatingFiltersValue, getDefaultRatingFilters } from '@/components/organizations/RatingFilters';
+import { RatingTable } from '@/components/RatingTable';
+import { getTranslation } from '@/lib/translations';
+import { RatingsService } from '@/lib/api/services/ratings';
+import type { PlayerInfoDto, DistrictDTO } from '@/lib/api/types';
+
+export default function DistrictDetailPage() {
+  const params = useParams();
+  const { language } = useLanguage();
+  const { getDistrict, loading: orgsLoading } = useOrganizations();
+  const t = getTranslation(language);
+
+  const districtId = params.id ? parseInt(params.id as string) : null;
+
+  const [filters, setFilters] = useState<RatingFiltersValue>(getDefaultRatingFilters);
+  const [ratingData, setRatingData] = useState<PlayerInfoDto[]>([]);
+  const [loadingRatings, setLoadingRatings] = useState(true);
+
+  // Get district info
+  const district: DistrictDTO | undefined = districtId ? getDistrict(districtId) : undefined;
+
+  // Fetch rating list when district or filters change
+  useEffect(() => {
+    if (!districtId) return;
+
+    const fetchRatings = async () => {
+      setLoadingRatings(true);
+      try {
+        const ratingsService = new RatingsService();
+        const response = await ratingsService.getDistrictRatingList(
+          districtId,
+          filters.ratingDate,
+          filters.ratingType,
+          filters.memberType
+        );
+
+        if (response.data) {
+          setRatingData(response.data);
+        } else {
+          setRatingData([]);
+        }
+      } catch (error) {
+        console.error('Failed to load ratings:', error);
+        setRatingData([]);
+      } finally {
+        setLoadingRatings(false);
+      }
+    };
+
+    fetchRatings();
+  }, [districtId, filters]);
+
+  if (!districtId) {
+    return (
+      <div className="text-center text-gray-600 dark:text-gray-400">
+        {t.pages.organizations.districts.selectDistrict}
+      </div>
+    );
+  }
+
+  if (orgsLoading) {
+    return (
+      <div className="text-center text-gray-600 dark:text-gray-400">
+        {t.pages.organizations.loading}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Page title with district name */}
+      <PageTitle
+        title={district?.name || t.pages.organizations.districts.title}
+        subtitle={t.pages.organizations.districts.subtitle}
+      />
+
+      {/* District Info */}
+      {district && (
+        <div className="flex flex-wrap gap-4 text-sm text-gray-600 dark:text-gray-400">
+          {district.city && <span>{district.city}</span>}
+          {district.email && <span>{district.email}</span>}
+          {district.url && (
+            <a
+              href={district.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              {district.url}
+            </a>
+          )}
+        </div>
+      )}
+
+      {/* District selector dropdown */}
+      <DistrictSelector selectedDistrictId={districtId} t={t} />
+
+      {/* Rating filters */}
+      <div className="space-y-4">
+        <h3 className="text-xl font-bold text-gray-900 dark:text-gray-200">
+          {t.pages.organizations.ratingList.title}
+        </h3>
+        <RatingFilters
+          value={filters}
+          onChange={setFilters}
+          t={t}
+        />
+      </div>
+
+      {/* Rating table */}
+      <RatingTable
+        players={ratingData}
+        ratingType={filters.ratingType}
+        loading={loadingRatings}
+        t={t}
+      />
+    </div>
+  );
+}

--- a/src/app/organizations/districts/layout.tsx
+++ b/src/app/organizations/districts/layout.tsx
@@ -1,0 +1,13 @@
+import { PageLayout } from '@/components/layout/PageLayout';
+
+export default function DistrictsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <PageLayout maxWidth="4xl">
+      {children}
+    </PageLayout>
+  );
+}

--- a/src/app/organizations/districts/page.tsx
+++ b/src/app/organizations/districts/page.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useOrganizations } from '@/context/OrganizationsContext';
+import { useLanguage } from '@/context/LanguageContext';
+import { getTranslation } from '@/lib/translations';
+
+export default function DistrictsPage() {
+  const router = useRouter();
+  const { districts, loading } = useOrganizations();
+  const { language } = useLanguage();
+  const t = getTranslation(language);
+
+  // Redirect to first district when data is loaded
+  useEffect(() => {
+    if (!loading && districts.length > 0) {
+      router.replace(`/organizations/districts/${districts[0].id}`);
+    }
+  }, [loading, districts, router]);
+
+  if (loading) {
+    return (
+      <div className="text-center text-gray-600 dark:text-gray-400">
+        {t.pages.organizations.loading}
+      </div>
+    );
+  }
+
+  // Show message while redirecting or if no districts
+  return (
+    <div className="p-6 rounded-lg border text-center bg-white dark:bg-dark-bg border-gray-200 dark:border-gray-700">
+      <p className="text-gray-600 dark:text-gray-400">
+        {t.pages.organizations.districts.selectDistrict}
+      </p>
+    </div>
+  );
+}

--- a/src/app/organizations/page.tsx
+++ b/src/app/organizations/page.tsx
@@ -1,95 +1,37 @@
 'use client';
 
-import { useState, useMemo, useEffect } from 'react';
+import { useMemo } from 'react';
+import { useRouter } from 'next/navigation';
 import { useLanguage } from '@/context/LanguageContext';
 import { useOrganizations } from '@/context/OrganizationsContext';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { PageTitle } from '@/components/PageTitle';
 import { SearchableSelectableList, SearchableSelectableListItem } from '@/components/SearchableSelectableList';
-import { SelectableList, SelectableListItem } from '@/components/SelectableList';
-import { RatingTable } from '@/components/RatingTable';
+import { Link } from '@/components/Link';
 import { getTranslation } from '@/lib/translations';
-import { RatingsService } from '@/lib/api/services/ratings';
-import { RatingType, PlayerCategory } from '@/lib/api/types';
-import type { ClubDTO, DistrictDTO, PlayerInfoDto } from '@/lib/api/types';
 
 export default function OrganizationsPage() {
+  const router = useRouter();
   const { language } = useLanguage();
-  const { districts, getAllClubs, getClubsByDistrict, getClub, loading, error } = useOrganizations();
+  const { getAllClubs, districts, loading, error } = useOrganizations();
   const t = getTranslation(language);
 
-  const [selectedDistrictId, setSelectedDistrictId] = useState<number | null>(null);
-  const [selectedClubId, setSelectedClubId] = useState<number | null>(null);
+  // Get all active clubs with rating players
+  const clubs = useMemo(() => {
+    return getAllClubs({ activeOnly: true, hasRatingPlayersOnly: true });
+  }, [getAllClubs]);
 
-  // Convert districts to dropdown items (with "All" option)
-  const districtItems: SearchableSelectableListItem[] = useMemo(() => {
-    const allOption: SearchableSelectableListItem = {
-      id: 'all',
-      label: t.pages.organizations.allDistricts,
-    };
-    const districtOptions = districts.map(district => ({
-      id: district.id,
-      label: district.name,
-      subtitle: district.city
-    }));
-    return [allOption, ...districtOptions];
-  }, [districts, t]);
-
-  // Get filtered clubs based on selected district
-  // By default, only show active clubs with rating players (matching official UI)
-  const filteredClubs = useMemo(() => {
-    const filterOptions = { activeOnly: true, hasRatingPlayersOnly: true };
-
-    if (!selectedDistrictId) {
-      return getAllClubs(filterOptions);
-    }
-    return getClubsByDistrict(selectedDistrictId, filterOptions);
-  }, [selectedDistrictId, getAllClubs, getClubsByDistrict]);
-
-  // Convert clubs to dropdown items (with "All" option)
+  // Convert clubs to searchable items
   const clubItems: SearchableSelectableListItem[] = useMemo(() => {
-    const allOption: SearchableSelectableListItem = {
-      id: 'all',
-      label: t.pages.organizations.allClubs,
-    };
-    const clubOptions = filteredClubs.map(club => ({
+    return clubs.map(club => ({
       id: club.id,
       label: club.name,
-      subtitle: club.city
+      subtitle: club.city || undefined,
     }));
-    return [allOption, ...clubOptions];
-  }, [filteredClubs, t]);
-
-  // Get selected district details
-  const selectedDistrict = useMemo(() => {
-    if (!selectedDistrictId) return null;
-    return districts.find(d => d.id === selectedDistrictId) || null;
-  }, [districts, selectedDistrictId]);
-
-  // Get selected club details
-  const selectedClub = useMemo(() => {
-    if (!selectedClubId) return null;
-    return getClub(selectedClubId) || null;
-  }, [selectedClubId, getClub]);
-
-  const handleDistrictSelect = (id: string | number) => {
-    // Handle "all" option
-    if (id === 'all') {
-      setSelectedDistrictId(null);
-      setSelectedClubId(null);
-    } else {
-      setSelectedDistrictId(id as number);
-      setSelectedClubId(null); // Reset club selection when district changes
-    }
-  };
+  }, [clubs]);
 
   const handleClubSelect = (id: string | number) => {
-    // Handle "all" option
-    if (id === 'all') {
-      setSelectedClubId(null);
-    } else {
-      setSelectedClubId(id as number);
-    }
+    router.push(`/organizations/clubs/${id}`);
   };
 
   if (loading) {
@@ -114,280 +56,57 @@ export default function OrganizationsPage() {
 
   return (
     <PageLayout maxWidth="4xl">
-      <div className="space-y-6">
-        <PageTitle title={t.pages.organizations.title} subtitle={t.pages.organizations.subtitle} />
+      <div className="space-y-8">
+        <PageTitle
+          title={t.pages.organizations.title}
+          subtitle={t.pages.organizations.subtitle}
+        />
 
-        {/* Dropdowns */}
+        {/* Club search */}
         <div className="space-y-4">
-          {/* District Selector */}
-          <div className="relative">
-            <SearchableSelectableList
-              items={districtItems}
-              selectedId={selectedDistrictId || 'all'}
-              onSelect={handleDistrictSelect}
-              title={t.pages.organizations.districtLabel}
-              placeholder={t.pages.organizations.selectDistrict}
-            />
-          </div>
-
-          {/* Club Selector */}
-          <div className="relative">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-200">
+            {t.pages.organizations.navigation.searchClubs}
+          </h2>
+          <div className="max-w-md">
             <SearchableSelectableList
               items={clubItems}
-              selectedId={selectedClubId || 'all'}
+              selectedId={null}
               onSelect={handleClubSelect}
-              title={t.pages.organizations.clubLabel}
-              placeholder={t.pages.organizations.selectClub}
+              placeholder={t.pages.organizations.clubs.searchPlaceholder}
             />
+          </div>
+          <div className="text-sm text-gray-600 dark:text-gray-400">
+            {clubs.length} {t.pages.organizations.clubs.activeClubs}
           </div>
         </div>
 
-        {/* Info Display */}
-        {selectedClub ? (
-          <ClubInfo club={selectedClub} t={t} />
-        ) : selectedDistrict ? (
-          <DistrictInfo district={selectedDistrict} clubCount={filteredClubs.length} t={t} />
-        ) : null}
+        {/* Navigation cards */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {/* SSF Ranking card */}
+          <Link href="/organizations/ssf" className="block group">
+            <div className="p-6 rounded-lg border bg-white dark:bg-dark-bg border-gray-200 dark:border-gray-700 hover:border-blue-300 dark:hover:border-blue-700 transition-colors">
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-200 group-hover:text-blue-600 dark:group-hover:text-blue-400">
+                {t.pages.organizations.navigation.ssfRanking}
+              </h3>
+              <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                {t.pages.organizations.ssf.description}
+              </p>
+            </div>
+          </Link>
+
+          {/* Districts card */}
+          <Link href="/organizations/districts" className="block group">
+            <div className="p-6 rounded-lg border bg-white dark:bg-dark-bg border-gray-200 dark:border-gray-700 hover:border-blue-300 dark:hover:border-blue-700 transition-colors">
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-200 group-hover:text-blue-600 dark:group-hover:text-blue-400">
+                {t.pages.organizations.navigation.districts}
+              </h3>
+              <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                {districts.length} {t.pages.organizations.districts.title.toLowerCase()}
+              </p>
+            </div>
+          </Link>
+        </div>
       </div>
     </PageLayout>
-  );
-}
-
-// Club Info Component
-function ClubInfo({ club, t }: { club: ClubDTO; t: ReturnType<typeof getTranslation> }) {
-  // Helper to get first day of current month
-  const getFirstOfMonth = () => {
-    const now = new Date();
-    return new Date(now.getFullYear(), now.getMonth(), 1);
-  };
-
-  const [ratingDate, setRatingDate] = useState<Date>(getFirstOfMonth());
-  const [ratingType, setRatingType] = useState<RatingType>(RatingType.STANDARD);
-  const [memberType, setMemberType] = useState<PlayerCategory>(PlayerCategory.ALL);
-  const [ratingData, setRatingData] = useState<PlayerInfoDto[]>([]);
-  const [loadingRatings, setLoadingRatings] = useState(false);
-
-  // Extract year from regYear timestamp
-  const regYear = club.regYear?.startDate
-    ? new Date(club.regYear.startDate).getFullYear().toString()
-    : '-';
-
-  // Format school club as Yes/No
-  const isSchoolClub = club.schoolClub === 1 ? t.pages.organizations.yes : t.pages.organizations.no;
-
-  // Create rating type dropdown items
-  const ratingTypeItems: SelectableListItem[] = useMemo(() => [
-    { id: RatingType.STANDARD, label: t.pages.organizations.ratingList.standard },
-    { id: RatingType.RAPID, label: t.pages.organizations.ratingList.rapid },
-    { id: RatingType.BLITZ, label: t.pages.organizations.ratingList.blitz },
-  ], [t]);
-
-  // Create member type dropdown items
-  const memberTypeItems: SelectableListItem[] = useMemo(() => [
-    { id: PlayerCategory.ALL, label: t.pages.organizations.ratingList.memberTypes.all },
-    { id: PlayerCategory.WOMEN, label: t.pages.organizations.ratingList.memberTypes.women },
-    { id: PlayerCategory.JUNIORS, label: t.pages.organizations.ratingList.memberTypes.juniors },
-    { id: PlayerCategory.CADETS, label: t.pages.organizations.ratingList.memberTypes.cadets },
-    { id: PlayerCategory.MINORS, label: t.pages.organizations.ratingList.memberTypes.minors },
-    { id: PlayerCategory.KIDS, label: t.pages.organizations.ratingList.memberTypes.kids },
-    { id: PlayerCategory.VETERANS, label: t.pages.organizations.ratingList.memberTypes.veterans },
-    { id: PlayerCategory.Y2C_ELEMENTARY, label: t.pages.organizations.ratingList.memberTypes.y2cElementary },
-    { id: PlayerCategory.Y2C_GRADE5, label: t.pages.organizations.ratingList.memberTypes.y2cGrade5 },
-    { id: PlayerCategory.Y2C_GRADE6, label: t.pages.organizations.ratingList.memberTypes.y2cGrade6 },
-    { id: PlayerCategory.Y2C_MIDDLE_SCHOOL, label: t.pages.organizations.ratingList.memberTypes.y2cMiddleSchool },
-  ], [t]);
-
-  // Helper to format date as YYYY-MM-DD in local timezone
-  const formatDateLocal = (date: Date): string => {
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const day = String(date.getDate()).padStart(2, '0');
-    return `${year}-${month}-${day}`;
-  };
-
-  // Create date dropdown items (12 months starting from current month)
-  const dateItems: SelectableListItem[] = useMemo(() => {
-    const items: SelectableListItem[] = [];
-    const now = new Date();
-
-    for (let i = 0; i < 12; i++) {
-      const date = new Date(now.getFullYear(), now.getMonth() - i, 1);
-      const dateStr = formatDateLocal(date);
-      items.push({
-        id: dateStr,
-        label: dateStr
-      });
-    }
-
-    return items;
-  }, []);
-
-  // Fetch rating list when club, date, rating type, or member type changes
-  useEffect(() => {
-    const fetchRatings = async () => {
-      setLoadingRatings(true);
-      try {
-        const ratingsService = new RatingsService();
-        const response = await ratingsService.getClubRatingList(
-          club.id,
-          ratingDate,
-          ratingType,
-          memberType
-        );
-
-        if (response.data) {
-          setRatingData(response.data);
-        } else {
-          setRatingData([]);
-        }
-      } catch (error) {
-        console.error('Failed to load ratings:', error);
-        setRatingData([]);
-      } finally {
-        setLoadingRatings(false);
-      }
-    };
-
-    fetchRatings();
-  }, [club.id, ratingDate, ratingType, memberType]);
-
-  return (
-    <div className="space-y-6">
-      <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-200">{club.name}</h2>
-
-      <div className="grid grid-cols-2 gap-4 text-sm">
-        <InfoField
-          label={t.pages.organizations.street}
-          value={club.street || '-'}
-        />
-        <InfoField
-          label={t.pages.organizations.website}
-          value={
-            club.url ? (
-              <a
-                href={club.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 dark:text-blue-400 hover:underline"
-              >
-                {club.url}
-              </a>
-            ) : '-'
-          }
-        />
-        <InfoField
-          label={t.pages.organizations.city}
-          value={club.city || '-'}
-        />
-        <InfoField
-          label={t.pages.organizations.email}
-          value={club.email || '-'}
-        />
-        <InfoField
-          label={t.pages.organizations.schoolClub}
-          value={isSchoolClub}
-        />
-        <InfoField
-          label={t.pages.organizations.regYear}
-          value={regYear}
-        />
-      </div>
-
-      {/* Rating List Section */}
-      <div className="space-y-4 mt-8">
-        <h3 className="text-xl font-bold text-gray-900 dark:text-gray-200">
-          {t.pages.organizations.ratingList.title}
-        </h3>
-
-        {/* Rating filters */}
-        <div className="grid grid-cols-3 gap-4">
-          <SelectableList
-            items={dateItems}
-            selectedId={formatDateLocal(ratingDate)}
-            onSelect={(id) => setRatingDate(new Date(id as string))}
-            title={t.pages.organizations.ratingList.dateLabel}
-            variant="dropdown"
-            density="compact"
-          />
-          <SelectableList
-            items={ratingTypeItems}
-            selectedId={ratingType}
-            onSelect={(id) => setRatingType(id as RatingType)}
-            title={t.pages.organizations.ratingList.ratingTypeLabel}
-            variant="dropdown"
-            density="compact"
-          />
-          <SelectableList
-            items={memberTypeItems}
-            selectedId={memberType}
-            onSelect={(id) => setMemberType(id as PlayerCategory)}
-            title={t.pages.organizations.ratingList.memberTypeLabel}
-            variant="dropdown"
-            density="compact"
-          />
-        </div>
-
-        {/* Rating table */}
-        <RatingTable
-          players={ratingData}
-          ratingType={ratingType}
-          loading={loadingRatings}
-          t={t}
-        />
-      </div>
-    </div>
-  );
-}
-
-// District Info Component
-function DistrictInfo({ district, clubCount, t }: { district: DistrictDTO; clubCount: number; t: ReturnType<typeof getTranslation> }) {
-  return (
-    <div className="space-y-4">
-      <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-200">{district.name}</h2>
-
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
-        <InfoField
-          label={t.pages.organizations.clubsCount}
-          value={clubCount.toString()}
-        />
-        {district.city && (
-          <InfoField
-            label={t.pages.organizations.city}
-            value={district.city}
-          />
-        )}
-        {district.email && (
-          <InfoField
-            label={t.pages.organizations.email}
-            value={district.email}
-          />
-        )}
-        {district.url && (
-          <InfoField
-            label={t.pages.organizations.website}
-            value={
-              <a
-                href={district.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 dark:text-blue-400 hover:underline"
-              >
-                {district.url}
-              </a>
-            }
-          />
-        )}
-      </div>
-    </div>
-  );
-}
-
-// Helper component for displaying labeled fields
-function InfoField({ label, value }: { label: string; value: React.ReactNode }) {
-  return (
-    <div>
-      <span className="font-semibold text-gray-700 dark:text-gray-300">{label}:</span>{' '}
-      <span className="text-gray-600 dark:text-gray-400">{value}</span>
-    </div>
   );
 }

--- a/src/app/organizations/ssf/page.tsx
+++ b/src/app/organizations/ssf/page.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useLanguage } from '@/context/LanguageContext';
+import { PageLayout } from '@/components/layout/PageLayout';
+import { PageTitle } from '@/components/PageTitle';
+import { RatingFilters, RatingFiltersValue, getDefaultRatingFilters } from '@/components/organizations/RatingFilters';
+import { RatingTable } from '@/components/RatingTable';
+import { getTranslation } from '@/lib/translations';
+import { RatingsService } from '@/lib/api/services/ratings';
+import type { PlayerInfoDto } from '@/lib/api/types';
+
+export default function SSFRankingPage() {
+  const { language } = useLanguage();
+  const t = getTranslation(language);
+
+  const [filters, setFilters] = useState<RatingFiltersValue>(getDefaultRatingFilters);
+  const [ratingData, setRatingData] = useState<PlayerInfoDto[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // Fetch rating list when filters change
+  useEffect(() => {
+    const fetchRatings = async () => {
+      setLoading(true);
+      try {
+        const ratingsService = new RatingsService();
+        const response = await ratingsService.getFederationRatingList(
+          filters.ratingDate,
+          filters.ratingType,
+          filters.memberType
+        );
+
+        if (response.data) {
+          setRatingData(response.data);
+        } else {
+          setRatingData([]);
+        }
+      } catch (error) {
+        console.error('Failed to load ratings:', error);
+        setRatingData([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchRatings();
+  }, [filters]);
+
+  const handleFiltersChange = (newFilters: RatingFiltersValue) => {
+    setFilters(newFilters);
+  };
+
+  return (
+    <PageLayout maxWidth="4xl">
+      <div className="space-y-6">
+        <PageTitle
+          title={t.pages.organizations.ssf.title}
+          subtitle={t.pages.organizations.ssf.subtitle}
+        />
+
+        <RatingFilters
+          value={filters}
+          onChange={handleFiltersChange}
+          t={t}
+        />
+
+        <RatingTable
+          players={ratingData}
+          ratingType={filters.ratingType}
+          loading={loading}
+          t={t}
+        />
+      </div>
+    </PageLayout>
+  );
+}

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useMemo } from 'react';
+import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
+
+export interface PaginationProps {
+  /** Current page number (1-indexed) */
+  currentPage: number;
+  /** Total number of items */
+  totalItems: number;
+  /** Number of items per page */
+  pageSize: number;
+  /** Callback when page changes */
+  onPageChange: (page: number) => void;
+  /** Maximum number of page buttons to show (default: 7) */
+  maxPageButtons?: number;
+}
+
+export function Pagination({
+  currentPage,
+  totalItems,
+  pageSize,
+  onPageChange,
+  maxPageButtons = 7,
+}: PaginationProps) {
+  const totalPages = Math.ceil(totalItems / pageSize);
+
+  // Generate page numbers to display
+  const pageNumbers = useMemo(() => {
+    if (totalPages <= maxPageButtons) {
+      return Array.from({ length: totalPages }, (_, i) => i + 1);
+    }
+
+    const pages: (number | 'ellipsis')[] = [];
+    const sideButtons = Math.floor((maxPageButtons - 3) / 2);
+
+    pages.push(1);
+
+    let start = Math.max(2, currentPage - sideButtons);
+    let end = Math.min(totalPages - 1, currentPage + sideButtons);
+
+    if (currentPage <= sideButtons + 2) {
+      end = Math.min(totalPages - 1, maxPageButtons - 2);
+    }
+
+    if (currentPage >= totalPages - sideButtons - 1) {
+      start = Math.max(2, totalPages - maxPageButtons + 3);
+    }
+
+    if (start > 2) {
+      pages.push('ellipsis');
+    }
+
+    for (let i = start; i <= end; i++) {
+      pages.push(i);
+    }
+
+    if (end < totalPages - 1) {
+      pages.push('ellipsis');
+    }
+
+    if (totalPages > 1) {
+      pages.push(totalPages);
+    }
+
+    return pages;
+  }, [currentPage, totalPages, maxPageButtons]);
+
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  const canGoPrev = currentPage > 1;
+  const canGoNext = currentPage < totalPages;
+
+  return (
+    <nav className="flex items-center justify-center gap-1" aria-label="Pagination">
+      <button
+        onClick={() => canGoPrev && onPageChange(currentPage - 1)}
+        disabled={!canGoPrev}
+        className={`p-2 rounded-lg transition-colors ${
+          canGoPrev
+            ? 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800'
+            : 'text-gray-300 dark:text-gray-600 cursor-not-allowed'
+        }`}
+        aria-label="Previous page"
+      >
+        <ChevronLeftIcon className="w-5 h-5" />
+      </button>
+
+      <div className="flex items-center gap-1">
+        {pageNumbers.map((page, index) => {
+          if (page === 'ellipsis') {
+            return (
+              <span
+                key={`ellipsis-${index}`}
+                className="px-2 py-1 text-gray-400 dark:text-gray-500"
+              >
+                ...
+              </span>
+            );
+          }
+
+          const isActive = page === currentPage;
+          return (
+            <button
+              key={page}
+              onClick={() => onPageChange(page)}
+              className={`min-w-[2.5rem] px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+                isActive
+                  ? 'bg-blue-600 text-white'
+                  : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800'
+              }`}
+              aria-current={isActive ? 'page' : undefined}
+            >
+              {page}
+            </button>
+          );
+        })}
+      </div>
+
+      <button
+        onClick={() => canGoNext && onPageChange(currentPage + 1)}
+        disabled={!canGoNext}
+        className={`p-2 rounded-lg transition-colors ${
+          canGoNext
+            ? 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800'
+            : 'text-gray-300 dark:text-gray-600 cursor-not-allowed'
+        }`}
+        aria-label="Next page"
+      >
+        <ChevronRightIcon className="w-5 h-5" />
+      </button>
+    </nav>
+  );
+}
+
+/** Helper to get paginated slice of data */
+export function paginateData<T>(data: T[], currentPage: number, pageSize: number): T[] {
+  const startIndex = (currentPage - 1) * pageSize;
+  return data.slice(startIndex, startIndex + pageSize);
+}

--- a/src/components/RatingTable.tsx
+++ b/src/components/RatingTable.tsx
@@ -21,16 +21,8 @@ interface RatingTableProps {
 export function RatingTable({ players, ratingType, loading, t }: RatingTableProps) {
   const router = useRouter();
 
-  // Add rank to each player
-  const playersWithRank = useMemo<PlayerWithRank[]>(() => {
-    return players.map((player, index) => ({
-      ...player,
-      rank: index + 1
-    }));
-  }, [players]);
-
-  // Get the appropriate rating value based on rating type
-  const getRating = (player: PlayerInfoDto): number => {
+  // Get rating value for a player based on rating type
+  const getRatingValue = (player: PlayerInfoDto): number => {
     switch (ratingType) {
       case RatingType.STANDARD:
         return player.elo?.rating || 0;
@@ -42,6 +34,15 @@ export function RatingTable({ players, ratingType, loading, t }: RatingTableProp
         return 0;
     }
   };
+
+  // Sort by rating (descending) and add rank
+  const playersWithRank = useMemo<PlayerWithRank[]>(() => {
+    const sorted = [...players].sort((a, b) => getRatingValue(b) - getRatingValue(a));
+    return sorted.map((player, index) => ({
+      ...player,
+      rank: index + 1
+    }));
+  }, [players, ratingType]);
 
   // Handle row click - navigate to player page
   const handleRowClick = (player: PlayerWithRank) => {
@@ -81,7 +82,7 @@ export function RatingTable({ players, ratingType, loading, t }: RatingTableProp
     {
       id: 'rating',
       header: t.pages.organizations.ratingList.tableHeaders.rating,
-      accessor: (player) => getRating(player) || '-',
+      accessor: (player) => getRatingValue(player) || '-',
       align: 'left',
       noWrap: true
     },
@@ -96,6 +97,14 @@ export function RatingTable({ players, ratingType, loading, t }: RatingTableProp
       loadingMessage={t.pages.organizations.ratingList.loading}
       onRowClick={handleRowClick}
       getRowKey={(player) => player.id}
+      pagination={{
+        pageSize: 50,
+        labels: {
+          showing: t.pages.organizations.pagination.showing,
+          of: t.pages.organizations.pagination.of,
+          itemName: t.pages.organizations.pagination.players,
+        },
+      }}
     />
   );
 }

--- a/src/components/TextDisplay.tsx
+++ b/src/components/TextDisplay.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import { ChevronDownIcon } from '@heroicons/react/24/outline';
+
+export interface TextDisplayProps {
+  /** The text content to display */
+  text: string;
+  /** Optional label shown before the text */
+  label?: string;
+  /** Number of lines to show when collapsed on small screens. If not set, shows all text. */
+  maxLines?: number;
+  /** Custom className for the container */
+  className?: string;
+}
+
+export function TextDisplay({
+  text,
+  label,
+  maxLines,
+  className = '',
+}: TextDisplayProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [needsExpansion, setNeedsExpansion] = useState(false);
+  const [isLargeScreen, setIsLargeScreen] = useState(false);
+  const textRef = useRef<HTMLSpanElement>(null);
+
+  // Track screen size - large screens don't truncate
+  useEffect(() => {
+    const checkScreenSize = () => {
+      setIsLargeScreen(window.innerWidth >= 768); // md breakpoint
+    };
+
+    checkScreenSize();
+    window.addEventListener('resize', checkScreenSize);
+    return () => window.removeEventListener('resize', checkScreenSize);
+  }, []);
+
+  // Check if text overflows the collapsed height (only on small screens)
+  useEffect(() => {
+    if (!maxLines || !textRef.current || isLargeScreen) {
+      setNeedsExpansion(false);
+      return;
+    }
+
+    const element = textRef.current;
+    const lineHeight = parseFloat(getComputedStyle(element).lineHeight);
+    const maxHeight = lineHeight * maxLines;
+    setNeedsExpansion(element.scrollHeight > maxHeight + 2);
+  }, [text, maxLines, isLargeScreen]);
+
+  // Only apply line-clamp on small screens when not expanded
+  const shouldTruncate = maxLines && !isExpanded && !isLargeScreen;
+  const lineClampStyle = shouldTruncate
+    ? {
+        display: '-webkit-box',
+        WebkitLineClamp: maxLines,
+        WebkitBoxOrient: 'vertical' as const,
+        overflow: 'hidden',
+      }
+    : {};
+
+  return (
+    <div className={className}>
+      {label && (
+        <span className="font-semibold text-gray-700 dark:text-gray-300">
+          {label}:{' '}
+        </span>
+      )}
+
+      <span
+        ref={textRef}
+        className="text-gray-600 dark:text-gray-400"
+        style={lineClampStyle}
+      >
+        {text}
+      </span>
+
+      {needsExpansion && (
+        <button
+          onClick={() => setIsExpanded(!isExpanded)}
+          className="ml-1 inline-flex items-center text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 transition-colors"
+          aria-label={isExpanded ? 'Collapse' : 'Expand'}
+        >
+          <ChevronDownIcon
+            className={`w-4 h-4 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+          />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/organizations/DistrictSelector.tsx
+++ b/src/components/organizations/DistrictSelector.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useRouter } from 'next/navigation';
+import { SelectableList, SelectableListItem } from '@/components/SelectableList';
+import { useOrganizations } from '@/context/OrganizationsContext';
+import type { getTranslation } from '@/lib/translations';
+
+export interface DistrictSelectorProps {
+  selectedDistrictId: number | null;
+  t: ReturnType<typeof getTranslation>;
+}
+
+export function DistrictSelector({ selectedDistrictId, t }: DistrictSelectorProps) {
+  const router = useRouter();
+  const { districts } = useOrganizations();
+
+  const districtItems: SelectableListItem[] = useMemo(() => {
+    return districts.map(district => ({
+      id: district.id,
+      label: district.name,
+    }));
+  }, [districts]);
+
+  const handleDistrictSelect = (id: string | number) => {
+    router.push(`/organizations/districts/${id}`);
+  };
+
+  return (
+    <SelectableList
+      items={districtItems}
+      selectedId={selectedDistrictId}
+      onSelect={handleDistrictSelect}
+      title={t.pages.organizations.districts.selectDistrict}
+      variant="dropdown"
+      density="compact"
+      transparent
+    />
+  );
+}

--- a/src/components/organizations/RatingFilters.tsx
+++ b/src/components/organizations/RatingFilters.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useMemo } from 'react';
+import { SelectableList, SelectableListItem } from '@/components/SelectableList';
+import { RatingType, PlayerCategory } from '@/lib/api/types';
+import type { getTranslation } from '@/lib/translations';
+
+export interface RatingFiltersValue {
+  ratingDate: Date;
+  ratingType: RatingType;
+  memberType: PlayerCategory;
+}
+
+export interface RatingFiltersProps {
+  value: RatingFiltersValue;
+  onChange: (value: RatingFiltersValue) => void;
+  t: ReturnType<typeof getTranslation>;
+  /** Number of months to show in date picker (default: 12) */
+  monthsToShow?: number;
+}
+
+/** Helper to format date as YYYY-MM-DD in local timezone */
+const formatDateLocal = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+export function RatingFilters({
+  value,
+  onChange,
+  t,
+  monthsToShow = 12,
+}: RatingFiltersProps) {
+  // Create rating type dropdown items
+  const ratingTypeItems: SelectableListItem[] = useMemo(() => [
+    { id: RatingType.STANDARD, label: t.pages.organizations.ratingList.standard },
+    { id: RatingType.RAPID, label: t.pages.organizations.ratingList.rapid },
+    { id: RatingType.BLITZ, label: t.pages.organizations.ratingList.blitz },
+  ], [t]);
+
+  // Create member type dropdown items
+  const memberTypeItems: SelectableListItem[] = useMemo(() => [
+    { id: PlayerCategory.ALL, label: t.pages.organizations.ratingList.memberTypes.all },
+    { id: PlayerCategory.WOMEN, label: t.pages.organizations.ratingList.memberTypes.women },
+    { id: PlayerCategory.JUNIORS, label: t.pages.organizations.ratingList.memberTypes.juniors },
+    { id: PlayerCategory.CADETS, label: t.pages.organizations.ratingList.memberTypes.cadets },
+    { id: PlayerCategory.MINORS, label: t.pages.organizations.ratingList.memberTypes.minors },
+    { id: PlayerCategory.KIDS, label: t.pages.organizations.ratingList.memberTypes.kids },
+    { id: PlayerCategory.VETERANS, label: t.pages.organizations.ratingList.memberTypes.veterans },
+    { id: PlayerCategory.Y2C_ELEMENTARY, label: t.pages.organizations.ratingList.memberTypes.y2cElementary },
+    { id: PlayerCategory.Y2C_GRADE5, label: t.pages.organizations.ratingList.memberTypes.y2cGrade5 },
+    { id: PlayerCategory.Y2C_GRADE6, label: t.pages.organizations.ratingList.memberTypes.y2cGrade6 },
+    { id: PlayerCategory.Y2C_MIDDLE_SCHOOL, label: t.pages.organizations.ratingList.memberTypes.y2cMiddleSchool },
+  ], [t]);
+
+  // Create date dropdown items (12 months starting from current month)
+  const dateItems: SelectableListItem[] = useMemo(() => {
+    const items: SelectableListItem[] = [];
+    const now = new Date();
+
+    for (let i = 0; i < monthsToShow; i++) {
+      const date = new Date(now.getFullYear(), now.getMonth() - i, 1);
+      const dateStr = formatDateLocal(date);
+      items.push({
+        id: dateStr,
+        label: dateStr
+      });
+    }
+
+    return items;
+  }, [monthsToShow]);
+
+  const handleDateChange = (id: string | number) => {
+    onChange({
+      ...value,
+      ratingDate: new Date(id as string),
+    });
+  };
+
+  const handleRatingTypeChange = (id: string | number) => {
+    onChange({
+      ...value,
+      ratingType: id as RatingType,
+    });
+  };
+
+  const handleMemberTypeChange = (id: string | number) => {
+    onChange({
+      ...value,
+      memberType: id as PlayerCategory,
+    });
+  };
+
+  return (
+    <div className="grid grid-cols-3 gap-2 sm:gap-4">
+      <SelectableList
+        items={dateItems}
+        selectedId={formatDateLocal(value.ratingDate)}
+        onSelect={handleDateChange}
+        title={t.pages.organizations.ratingList.dateLabel}
+        variant="dropdown"
+        density="compact"
+      />
+      <SelectableList
+        items={ratingTypeItems}
+        selectedId={value.ratingType}
+        onSelect={handleRatingTypeChange}
+        title={t.pages.organizations.ratingList.ratingTypeLabel}
+        variant="dropdown"
+        density="compact"
+      />
+      <SelectableList
+        items={memberTypeItems}
+        selectedId={value.memberType}
+        onSelect={handleMemberTypeChange}
+        title={t.pages.organizations.ratingList.memberTypeLabel}
+        variant="dropdown"
+        density="compact"
+      />
+    </div>
+  );
+}
+
+/** Helper to get default filter values */
+export function getDefaultRatingFilters(): RatingFiltersValue {
+  const now = new Date();
+  return {
+    ratingDate: new Date(now.getFullYear(), now.getMonth(), 1),
+    ratingType: RatingType.STANDARD,
+    memberType: PlayerCategory.ALL,
+  };
+}

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -364,7 +364,6 @@ export interface Translations {
       email: string;
       website: string;
       schoolClub: string;
-      regYear: string;
       yes: string;
       no: string;
       loading: string;
@@ -398,6 +397,35 @@ export interface Translations {
         };
         loading: string;
         noPlayers: string;
+      };
+      ssf: {
+        title: string;
+        subtitle: string;
+        description: string;
+      };
+      districts: {
+        title: string;
+        subtitle: string;
+        selectDistrict: string;
+      };
+      clubs: {
+        title: string;
+        subtitle: string;
+        searchPlaceholder: string;
+        browseByDistrict: string;
+        activeClubs: string;
+        district: string;
+      };
+      navigation: {
+        ssfRanking: string;
+        districts: string;
+        clubs: string;
+        searchClubs: string;
+      };
+      pagination: {
+        showing: string;
+        of: string;
+        players: string;
       };
     };
   };
@@ -768,7 +796,6 @@ const translations: Record<Language, Translations> = {
         email: 'Email',
         website: 'Website',
         schoolClub: 'School Club',
-        regYear: 'Registered',
         yes: 'Yes',
         no: 'No',
         loading: 'Loading...',
@@ -802,6 +829,35 @@ const translations: Record<Language, Translations> = {
           },
           loading: 'Loading ratings...',
           noPlayers: 'No players found',
+        },
+        ssf: {
+          title: 'SSF National Ranking',
+          subtitle: 'Swedish Chess Federation national ranking list.',
+          description: 'View the complete ranking of all rated players in Sweden.',
+        },
+        districts: {
+          title: 'Districts',
+          subtitle: 'Explore chess districts in Sweden.',
+          selectDistrict: 'Select District',
+        },
+        clubs: {
+          title: 'Clubs',
+          subtitle: 'Find and explore chess clubs in Sweden.',
+          searchPlaceholder: 'Search for a club...',
+          browseByDistrict: 'Or browse by district',
+          activeClubs: 'active clubs',
+          district: 'District',
+        },
+        navigation: {
+          ssfRanking: 'SSF Ranking',
+          districts: 'Districts',
+          clubs: 'Clubs',
+          searchClubs: 'Search Clubs',
+        },
+        pagination: {
+          showing: 'Showing',
+          of: 'of',
+          players: 'players',
         },
       },
     },
@@ -1170,7 +1226,6 @@ const translations: Record<Language, Translations> = {
         email: 'E-post',
         website: 'Webbplats',
         schoolClub: 'Skolklubb',
-        regYear: 'Registrerad',
         yes: 'Ja',
         no: 'Nej',
         loading: 'Laddar...',
@@ -1204,6 +1259,35 @@ const translations: Record<Language, Translations> = {
           },
           loading: 'Laddar rating...',
           noPlayers: 'Inga spelare hittades',
+        },
+        ssf: {
+          title: 'SSF Nationell Ranking',
+          subtitle: 'Svenska Schackförbundets nationella rankinglista.',
+          description: 'Se den kompletta rankingen av alla rankade spelare i Sverige.',
+        },
+        districts: {
+          title: 'Distrikt',
+          subtitle: 'Utforska schackdistrikt i Sverige.',
+          selectDistrict: 'Välj distrikt',
+        },
+        clubs: {
+          title: 'Klubbar',
+          subtitle: 'Hitta och utforska schackklubbar i Sverige.',
+          searchPlaceholder: 'Sök efter en klubb...',
+          browseByDistrict: 'Eller bläddra efter distrikt',
+          activeClubs: 'aktiva klubbar',
+          district: 'Distrikt',
+        },
+        navigation: {
+          ssfRanking: 'SSF Ranking',
+          districts: 'Distrikt',
+          clubs: 'Klubbar',
+          searchClubs: 'Sök klubbar',
+        },
+        pagination: {
+          showing: 'Visar',
+          of: 'av',
+          players: 'spelare',
         },
       },
     },


### PR DESCRIPTION
## Summary

- **Districts**: New dropdown-based layout replacing sidebar, with district detail pages showing rating lists
- **Clubs**: Detail pages with description (expandable on mobile), rating lists sorted by ELO
- **SSF National Ranking**: Dedicated page for federation-wide rankings
- **Table pagination**: Built-in pagination with language-agnostic display (`1-50 / 3334`) and i18n support
- **Rating filters**: Now stay on one row across all screen sizes
- **New components**: `Pagination`, `TextDisplay`, `DistrictSelector`, `RatingFilters`
- **Commands**: Added `/commit` for validation workflow, updated `/release` with changelog generation

## Changes

- Rating tables now sort by selected ELO type (standard/rapid/blitz)
- `TextDisplay` component with responsive truncation (collapses on mobile, full text on desktop)
- Removed misleading `regYear` field from clubs (showed registration period, not founding year)
- Simplified SSF page to use Table's built-in pagination

## Test plan

- [ ] Navigate to `/organizations/districts/[id]` - verify dropdown selector and rating list
- [ ] Navigate to `/organizations/clubs/[id]` - verify description display and rating list
- [ ] Navigate to `/organizations/ssf` - verify pagination and sorting
- [ ] Test on mobile viewport - verify filters stay on one row, descriptions truncate
- [ ] Switch ELO types - verify table re-sorts correctly