### PR TITLE
feat: add historical ELO support for tournaments

### DIFF
--- a/src/context/GroupResultsContext.tsx
+++ b/src/context/GroupResultsContext.tsx
@@ -3,6 +3,14 @@
 import { createContext, useContext } from 'react';
 import { TournamentEndResultDto, TournamentRoundResultDto, PlayerInfoDto, TeamTournamentEndResultDto } from '@/lib/api/types';
 
+/**
+ * Request for fetching a player's info at a specific historical date
+ */
+export interface PlayerDateRequest {
+  playerId: number;
+  date: number;  // Unix timestamp in milliseconds
+}
+
 export interface GroupResultsContextValue {
   // Tournament type detection
   isTeamTournament: boolean;
@@ -30,6 +38,11 @@ export interface GroupResultsContextValue {
   getPlayerElo: (playerId: number) => string;
   getPlayerClubId: (playerId: number) => number | null;
   getClubName: (clubId: number) => string;
+
+  // Historical ELO functions for team tournaments
+  fetchPlayersByDate: (requests: PlayerDateRequest[]) => Promise<void>;
+  getPlayerByDate: (playerId: number, date: number) => PlayerInfoDto | undefined;
+  getPlayerEloByDate: (playerId: number, date: number) => string;
 }
 
 const GroupResultsContext = createContext<GroupResultsContextValue | null>(null);

--- a/src/lib/api/utils/eloCalculations.ts
+++ b/src/lib/api/utils/eloCalculations.ts
@@ -110,7 +110,8 @@ export function calculateTournamentStats(
   let totalScore = 0;
 
   for (const match of matches) {
-    if (match.opponentRating !== null) {
+    // Only include matches where opponent has a valid rating (not null, undefined, 0, or NaN)
+    if (match.opponentRating && match.opponentRating > 0) {
       // Calculate rating change for this match
       const change = calculateRatingChange(
         playerRating,


### PR DESCRIPTION
## Summary

- Add date-aware player info caching to show accurate historical ELO ratings for each round
- Implement `fetchPlayersByDate` with month-based grouping and controlled concurrency (SSF ELO updates monthly)
- Lazy-load historical player data when users expand matches or select rounds
- Use historical ELO in player detail view for accurate per-round rating change calculations

## Background

Tournaments can span multiple months. Previously, we fetched player ELO ratings for the current date, but this showed inaccurate ratings for rounds played months ago. Now the system fetches the ELO for the date each round was played.

This applies to both:
- **Team tournaments**: Historical ELO loaded when expanding a team match
- **Individual tournaments**: Historical ELO loaded when selecting a round tab

## Test plan

- [ ] Navigate to a tournament that spans multiple months (team or individual)
- [ ] Expand/select different rounds and verify ELO shown matches historical values
- [ ] Verify viewing the same round twice doesn't trigger additional API calls
- [ ] Click on a player to view their tournament performance and verify per-round ELO is historical