### PR TITLE
Show registration list for non-started tournaments

### DIFF
--- a/src/app/results/[tournamentId]/[groupId]/layout.tsx
+++ b/src/app/results/[tournamentId]/[groupId]/layout.tsx
@@ -336,6 +336,7 @@ export default function GroupResultsLayout({ children }: { children: ReactNode }
     groupStartDate,
     groupEndDate,
     rankingAlgorithm,
+    tournamentState: tournament?.state ?? null,
     loading,
     error,
     getPlayerName,

--- a/src/components/results/RegistrationTable.tsx
+++ b/src/components/results/RegistrationTable.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import React from 'react';
+import { Table, TableColumn, TableDensity, DensityThresholds } from '@/components/Table';
+import { TournamentEndResultDto } from '@/lib/api/types';
+import { formatRatingWithType, getPlayerRatingByAlgorithm, formatPlayerName } from '@/lib/api';
+import { useLanguage } from '@/context/LanguageContext';
+import { getTranslation } from '@/lib/translations';
+
+export interface RegistrationTableProps {
+  /** Tournament end results data (used for registration display) */
+  results: TournamentEndResultDto[];
+  /** Ranking algorithm for rating display */
+  rankingAlgorithm?: number | null;
+  /** Optional loading state */
+  loading?: boolean;
+  /** Optional error message */
+  error?: string;
+  /** Callback when a row is clicked */
+  onRowClick?: (result: TournamentEndResultDto) => void;
+  /**
+   * Table density - controls padding and font size.
+   * If not provided, auto-density is enabled (compact on mobile, row-count based on desktop)
+   */
+  density?: TableDensity;
+  /**
+   * Thresholds for auto-density selection on desktop.
+   * Default: comfortable <= 10 rows, normal <= 20 rows, compact > 20 rows
+   */
+  densityThresholds?: DensityThresholds;
+}
+
+// Extended type that includes registration order
+interface RegistrationRowData extends TournamentEndResultDto {
+  registrationOrder: number;
+}
+
+/**
+ * Table component for displaying registered players in non-started tournaments.
+ * Shows a simpler view than FinalResultsTable: position, name, club, and rating.
+ */
+export function RegistrationTable({
+  results,
+  rankingAlgorithm,
+  loading = false,
+  error,
+  onRowClick,
+  density,
+  densityThresholds
+}: RegistrationTableProps) {
+  const { language } = useLanguage();
+  const t = getTranslation(language);
+
+  // Add registration order to each result
+  const dataWithOrder: RegistrationRowData[] = results.map((result, index) => ({
+    ...result,
+    registrationOrder: index + 1
+  }));
+
+  const columns: TableColumn<RegistrationRowData>[] = [
+    {
+      id: 'pos',
+      header: t.pages.tournamentResults.registrationTable.pos,
+      accessor: (row) => row.registrationOrder,
+      align: 'left',
+      noWrap: true
+    },
+    {
+      id: 'name',
+      header: t.pages.tournamentResults.registrationTable.name,
+      accessor: (row) => row.playerInfo ? formatPlayerName(row.playerInfo.firstName, row.playerInfo.lastName, row.playerInfo.elo?.title) : 'Unknown Player',
+      align: 'left'
+    },
+    {
+      id: 'club',
+      header: t.pages.tournamentResults.registrationTable.club,
+      accessor: (row) => row.playerInfo?.club || '-',
+      align: 'left',
+      cellClassName: 'max-w-[9ch] sm:max-w-none overflow-hidden whitespace-nowrap sm:whitespace-normal'
+    },
+    {
+      id: 'rating',
+      header: t.pages.tournamentResults.registrationTable.rating,
+      accessor: (row) => {
+        const { rating, ratingType } = getPlayerRatingByAlgorithm(row.playerInfo?.elo, rankingAlgorithm);
+        return formatRatingWithType(rating, ratingType, language);
+      },
+      align: 'left',
+      noWrap: true
+    }
+  ];
+
+  // Wrapper to handle the original TournamentEndResultDto in onRowClick
+  const handleRowClick = onRowClick
+    ? (row: RegistrationRowData) => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { registrationOrder, ...originalResult } = row;
+        onRowClick(originalResult as TournamentEndResultDto);
+      }
+    : undefined;
+
+  return (
+    <Table
+      data={dataWithOrder}
+      columns={columns}
+      loading={loading}
+      error={error}
+      emptyMessage={t.pages.tournamentResults.registrationTable.noRegistrations}
+      loadingMessage={t.pages.tournamentResults.registrationTable.loadingRegistrations}
+      onRowClick={handleRowClick}
+      getRowKey={(row) => row.playerInfo?.id || row.contenderId}
+      density={density}
+      densityThresholds={densityThresholds}
+    />
+  );
+}
+
+export default RegistrationTable;

--- a/src/context/GroupResultsContext.tsx
+++ b/src/context/GroupResultsContext.tsx
@@ -30,6 +30,7 @@ export interface GroupResultsContextValue {
   groupStartDate: string | null;
   groupEndDate: string | null;
   rankingAlgorithm: number | null;
+  tournamentState: number | null;
   loading: boolean;
   error: string | null;
 

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -347,6 +347,15 @@ export interface Translations {
         groupCancelled: string;
         resultsComing: string;
       };
+      registrationTable: {
+        title: string;
+        pos: string;
+        name: string;
+        club: string;
+        rating: string;
+        noRegistrations: string;
+        loadingRegistrations: string;
+      };
     };
     organizations: {
       title: string;
@@ -779,6 +788,15 @@ const translations: Record<Language, Translations> = {
           groupCancelled: 'This group may have been cancelled',
           resultsComing: 'Results coming soon...',
         },
+        registrationTable: {
+          title: 'Registered Players',
+          pos: '#',
+          name: 'Name',
+          club: 'Club',
+          rating: 'Rating',
+          noRegistrations: 'No registered players',
+          loadingRegistrations: 'Loading registrations...',
+        },
       },
       organizations: {
         title: 'Clubs & Districts',
@@ -1208,6 +1226,15 @@ const translations: Record<Language, Translations> = {
           noResultsAvailable: 'Inga resultat tillgängliga',
           groupCancelled: 'Denna grupp kan ha ställts in',
           resultsComing: 'Resultat kommer snart...',
+        },
+        registrationTable: {
+          title: 'Anmälda spelare',
+          pos: '#',
+          name: 'Namn',
+          club: 'Klubb',
+          rating: 'Rating',
+          noRegistrations: 'Inga anmälda spelare',
+          loadingRegistrations: 'Laddar anmälningar...',
         },
       },
       organizations: {


### PR DESCRIPTION
## Summary

- Add `RegistrationTable` component with simpler columns (#, Name, Club, Rating) for non-started tournaments
- Detect tournament state via `TournamentState.REGISTRATION` to show appropriate view
- Display "Anmälda spelare" / "Registered Players" header instead of misleading "Slutresultat"
- Hide round-by-round section for non-started tournaments (no more "No round results" noise)
- Show group start date as subtitle for registration lists

## Test plan

- [ ] Navigate to a non-started tournament group → should show "Anmälda spelare" header with simple table
- [ ] Navigate to a started/finished tournament → should show "Slutresultat" with full results table
- [ ] Verify round-by-round section is hidden for non-started tournaments
- [ ] Test player click navigates to detail page in both modes
- [ ] Test both Swedish and English translations
- [ ] Test light and dark mode