### PR TITLE
Add live tournament updates feature

### DIFF
--- a/src/components/results/LiveUpdatesToggle.tsx
+++ b/src/components/results/LiveUpdatesToggle.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useLanguage } from '@/context/LanguageContext';
+import { getTranslation } from '@/lib/translations';
+
+interface LiveUpdatesToggleProps {
+  enabled: boolean;
+  onToggle: (enabled: boolean) => void;
+  lastUpdated: Date | null;
+  isRefreshing: boolean;
+  onManualRefresh: () => void;
+}
+
+export function LiveUpdatesToggle({
+  enabled,
+  onToggle,
+  lastUpdated,
+  isRefreshing,
+  onManualRefresh,
+}: LiveUpdatesToggleProps) {
+  const { language } = useLanguage();
+  const t = getTranslation(language);
+
+  const formatTime = (date: Date): string => {
+    return date.toLocaleTimeString(language === 'sv' ? 'sv-SE' : 'en-US', {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+  };
+
+  return (
+    <div className="flex items-center gap-3 text-sm">
+      {/* Manual Refresh Button */}
+      <button
+        onClick={onManualRefresh}
+        disabled={isRefreshing}
+        className="p-1.5 rounded-md text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        title={t.pages.tournamentResults.liveUpdates.refresh}
+        aria-label={t.pages.tournamentResults.liveUpdates.refresh}
+      >
+        <svg
+          className={`w-4 h-4 ${isRefreshing ? 'animate-spin' : ''}`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+          />
+        </svg>
+      </button>
+
+      {/* Live Updates Toggle */}
+      <label className="flex items-center gap-2 cursor-pointer select-none">
+        <span className={`transition-colors ${
+          enabled
+            ? 'text-green-600 dark:text-green-400 font-medium'
+            : 'text-gray-600 dark:text-gray-400'
+        }`}>
+          {t.pages.tournamentResults.liveUpdates.label}
+        </span>
+        <div className="relative">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => onToggle(e.target.checked)}
+            className="sr-only peer"
+          />
+          <div className="w-9 h-5 bg-gray-200 dark:bg-gray-700 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-blue-500 peer-focus:ring-offset-2 dark:peer-focus:ring-offset-dark-bg rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-blue-600"></div>
+        </div>
+      </label>
+
+      {/* Last Updated Timestamp */}
+      {lastUpdated && (
+        <span className="text-gray-500 dark:text-gray-500 text-xs">
+          {t.pages.tournamentResults.liveUpdates.lastUpdated}: {formatTime(lastUpdated)}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/context/GroupResultsContext.tsx
+++ b/src/context/GroupResultsContext.tsx
@@ -52,6 +52,12 @@ export interface GroupResultsContextValue {
   getRoundRatedType: (roundNumber: number) => number | undefined;
   /** Get formatted ELO for a player at a specific date and round (uses round-specific rating type) */
   getPlayerEloByDateAndRound: (playerId: number, date: number, roundNumber?: number) => string;
+
+  // Live updates
+  /** Refresh all tournament results data */
+  refreshResults: () => Promise<void>;
+  /** Timestamp of last data refresh */
+  lastUpdated: Date | null;
 }
 
 const GroupResultsContext = createContext<GroupResultsContextValue | null>(null);

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useResponsiveDataPoints, type ResponsiveDataPointsOptions } from './useResponsiveDataPoints';
+export { useLiveUpdates, type LiveUpdatesState, type UseLiveUpdatesOptions } from './useLiveUpdates';

--- a/src/hooks/useLiveUpdates.ts
+++ b/src/hooks/useLiveUpdates.ts
@@ -1,0 +1,79 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+export interface LiveUpdatesState {
+  enabled: boolean;
+  lastUpdated: Date | null;
+  isRefreshing: boolean;
+}
+
+export interface UseLiveUpdatesOptions {
+  /** Polling interval in milliseconds. Default: 30000 (30 seconds) */
+  pollInterval?: number;
+  /** Callback to refresh data */
+  onRefresh: () => Promise<void>;
+}
+
+const DEFAULT_POLL_INTERVAL = 30000; // 30 seconds
+
+export function useLiveUpdates(options: UseLiveUpdatesOptions) {
+  const { pollInterval = DEFAULT_POLL_INTERVAL, onRefresh } = options;
+
+  const [enabled, setEnabled] = useState(false);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  // Use ref to track if a refresh is in progress to avoid overlapping
+  const refreshInProgress = useRef(false);
+
+  const doRefresh = useCallback(async () => {
+    if (refreshInProgress.current) return;
+
+    refreshInProgress.current = true;
+    setIsRefreshing(true);
+
+    try {
+      await onRefresh();
+      setLastUpdated(new Date());
+    } catch (error) {
+      console.error('Live update refresh failed:', error);
+    } finally {
+      setIsRefreshing(false);
+      refreshInProgress.current = false;
+    }
+  }, [onRefresh]);
+
+  // Manual refresh function
+  const manualRefresh = useCallback(async () => {
+    await doRefresh();
+  }, [doRefresh]);
+
+  // Set up polling when enabled
+  useEffect(() => {
+    if (!enabled) return;
+
+    // Do an initial refresh when enabling
+    doRefresh();
+
+    // Set up interval for subsequent refreshes
+    const intervalId = setInterval(() => {
+      doRefresh();
+    }, pollInterval);
+
+    // Cleanup on disable or unmount
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, [enabled, pollInterval, doRefresh]);
+
+  return {
+    state: {
+      enabled,
+      lastUpdated,
+      isRefreshing,
+    },
+    setEnabled,
+    manualRefresh,
+  };
+}

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -363,6 +363,11 @@ export interface Translations {
         noRegistrations: string;
         loadingRegistrations: string;
       };
+      liveUpdates: {
+        label: string;
+        lastUpdated: string;
+        refresh: string;
+      };
     };
     organizations: {
       title: string;
@@ -811,6 +816,11 @@ const translations: Record<Language, Translations> = {
           noRegistrations: 'No registered players',
           loadingRegistrations: 'Loading registrations...',
         },
+        liveUpdates: {
+          label: 'Live',
+          lastUpdated: 'Updated',
+          refresh: 'Refresh',
+        },
       },
       organizations: {
         title: 'Clubs & Districts',
@@ -1256,6 +1266,11 @@ const translations: Record<Language, Translations> = {
           rating: 'Rating',
           noRegistrations: 'Inga anmälda spelare',
           loadingRegistrations: 'Laddar anmälningar...',
+        },
+        liveUpdates: {
+          label: 'Live',
+          lastUpdated: 'Uppdaterad',
+          refresh: 'Uppdatera',
         },
       },
       organizations: {


### PR DESCRIPTION
## Summary
- Add opt-in "Live Updates" mode for following active tournaments without manual page refresh
- Refresh button for manual on-demand data refresh
- "Last updated" timestamp shows when data was last fetched
- Live controls hidden for finished tournaments (showing final results)

## Changes
- New `useLiveUpdates` hook with configurable polling interval (default 30s)
- New `LiveUpdatesToggle` component with refresh button, toggle switch, and timestamp
- Extended `GroupResultsContext` with `refreshResults` and `lastUpdated`
- Refactored layout data fetching to support refresh without loading flash
- Added English/Swedish translations for live updates UI
- Green "Live" label highlight when enabled

## Test plan
- [ ] Navigate to an active/ongoing tournament
- [ ] Verify refresh button updates data and timestamp
- [ ] Enable live toggle, verify polling starts (check network tab)
- [ ] Disable live toggle, verify polling stops
- [ ] Verify expanded round stays expanded after refresh
- [ ] Navigate to a finished tournament, verify live controls are hidden
- [ ] Test on mobile: verify controls appear below thinking time info

Closes #18, closes #19