### PR TITLE
Show upcoming/registered tournaments in player profile

### DIFF
--- a/src/app/players/[memberId]/layout.tsx
+++ b/src/app/players/[memberId]/layout.tsx
@@ -64,8 +64,11 @@ export default function PlayerLayout({ children }: { children: ReactNode }) {
         }
         setCurrentPlayerLoading(false);
 
-        // Step 1: Fetch all games for the member
-        const gamesResponse = await resultsService.getMemberGames(memberId);
+        // Step 1: Fetch games and tournament results in parallel
+        const [gamesResponse, memberResultsResponse] = await Promise.all([
+          resultsService.getMemberGames(memberId),
+          resultsService.getMemberTournamentResults(memberId),
+        ]);
 
         if (gamesResponse.status !== 200 || !gamesResponse.data) {
           throw new Error('Failed to fetch game data');
@@ -92,8 +95,20 @@ export default function PlayerLayout({ children }: { children: ReactNode }) {
           groupIds.add(game.groupiD);
         });
 
-        // Step 3: Fetch tournaments FIRST (priority - needed for Individual, Team, and Opponents tabs)
-        const newTournamentMap = await getOrFetchTournaments(Array.from(groupIds));
+        // Step 3: Identify upcoming tournament group IDs (registered but no games played)
+        const playedGroupIds = new Set(groupIds);
+        const upcomingGroupIds: number[] = [];
+        if (memberResultsResponse.status === 200 && memberResultsResponse.data) {
+          for (const result of memberResultsResponse.data) {
+            if (!playedGroupIds.has(result.groupId)) {
+              upcomingGroupIds.push(result.groupId);
+            }
+          }
+        }
+
+        // Step 3b: Fetch tournaments (including upcoming) - needed for Individual, Team, and Opponents tabs
+        const allGroupIds = [...Array.from(groupIds), ...upcomingGroupIds];
+        const newTournamentMap = await getOrFetchTournaments(allGroupIds);
 
         setTournamentMap(newTournamentMap);
 
@@ -156,6 +171,28 @@ export default function PlayerLayout({ children }: { children: ReactNode }) {
             draws: stats.draws,
             losses: stats.losses,
             totalPoints: stats.totalPoints,
+          });
+        }
+
+        // Add upcoming (registered but not yet played) individual tournaments
+        for (const groupId of upcomingGroupIds) {
+          const tournament = newTournamentMap.get(groupId);
+          if (!tournament) continue;
+          if (isTeamTournament(tournament.type)) continue;
+
+          const groupResult = findTournamentGroup(tournament, groupId);
+          participations.push({
+            groupId,
+            tournament,
+            gameCount: 0,
+            groupName: groupResult?.group.name || '',
+            groupStartDate: groupResult?.group.start || tournament.start,
+            groupEndDate: groupResult?.group.end || tournament.end,
+            className: groupResult?.parentClass.className || '',
+            hasMultipleClasses: groupResult?.hasMultipleClasses ?? false,
+            isTeam: false,
+            wins: 0, draws: 0, losses: 0, totalPoints: 0,
+            isUpcoming: true,
           });
         }
 

--- a/src/components/player/PlayerTournamentList.tsx
+++ b/src/components/player/PlayerTournamentList.tsx
@@ -27,6 +27,7 @@ export interface PlayerTournamentListProps {
     place: string;
     points: string;
     outcome: string;
+    registered?: string;
   };
   /** Language for date formatting */
   language?: 'sv' | 'en';
@@ -249,13 +250,20 @@ export function PlayerTournamentList({
                 </div>
               </div>
               <div className="text-right ml-4 flex-shrink-0">
-                {/* Total points and outcome (W/D/L) */}
-                <div className={`${classes.fontSize} font-medium text-gray-900 dark:text-gray-200`}>
-                  {t.points}: {tournamentData.totalPoints}
-                </div>
-                <div className={`${classes.metaSize} text-gray-600 dark:text-gray-400`}>
-                  {t.outcome}: {tournamentData.wins}/{tournamentData.draws}/{tournamentData.losses}
-                </div>
+                {tournamentData.isUpcoming ? (
+                  <span className={`${classes.fontSize} font-medium text-blue-600 dark:text-blue-400`}>
+                    {t.registered || 'Registered'}
+                  </span>
+                ) : (
+                  <>
+                    <div className={`${classes.fontSize} font-medium text-gray-900 dark:text-gray-200`}>
+                      {t.points}: {tournamentData.totalPoints}
+                    </div>
+                    <div className={`${classes.metaSize} text-gray-600 dark:text-gray-400`}>
+                      {t.outcome}: {tournamentData.wins}/{tournamentData.draws}/{tournamentData.losses}
+                    </div>
+                  </>
+                )}
               </div>
             </div>
           </Link>

--- a/src/context/PlayerContext.tsx
+++ b/src/context/PlayerContext.tsx
@@ -22,6 +22,7 @@ export interface TournamentParticipation {
   draws: number;
   losses: number;
   totalPoints: number;  // Sum of points using the tournament's point system
+  isUpcoming?: boolean;  // Registered but no games played yet
 }
 
 export interface PlayerContextValue {

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -265,6 +265,7 @@ export interface Translations {
         place: string;
         points: string;
         outcome: string;
+        registered: string;
       };
       tabs: {
         individual: string;
@@ -810,6 +811,7 @@ const translations: Record<Language, Translations> = {
           place: 'Place',
           points: 'Points',
           outcome: 'Outcome',
+          registered: 'Registered',
         },
         tabs: {
           individual: 'Individual',
@@ -1353,6 +1355,7 @@ const translations: Record<Language, Translations> = {
           place: 'Placering',
           points: 'Poäng',
           outcome: 'Utfall',
+          registered: 'Anmäld',
         },
         tabs: {
           individual: 'Individuell',


### PR DESCRIPTION
## Summary
- Fetch `getMemberTournamentResults` in parallel with `getMemberGames` to discover tournaments a player is registered in but hasn't played yet
- Show these upcoming tournaments in the Individual tab with a "Registered" / "Anmäld" label instead of points/outcome stats
- Only individual tournaments included (team registrations filtered out)

## Test plan
- [ ] `pnpm check` passes (typecheck, lint, test, build)
- [ ] Navigate to a player profile → Individual tab → verify upcoming tournaments appear with "Registered" label
- [ ] Verify played tournaments still show Points/Outcome as before
- [ ] Test in both English and Swedish