### PR TITLE
Remove stale TODO comment from tournament player detail page

### DIFF
--- a/src/app/results/[tournamentId]/[groupId]/[memberId]/page.tsx
+++ b/src/app/results/[tournamentId]/[groupId]/[memberId]/page.tsx
@@ -1,9 +1,5 @@
 'use client';
 
-// TODO: Verify rating algorithm implementation against schack.se's actual code
-// Current implementation is based on constant names and educated guesses
-// Waiting for official implementation details from schack.se
-
 import { useState, useEffect } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { PageLayout } from '@/components/layout/PageLayout';


### PR DESCRIPTION
## Janitor Agent - Remove stale TODO comment from tournament player detail page

A multi-line TODO comment at the top of the tournament player detail page notes that the rating algorithm implementation is unverified and waiting for official details. Per the changelog, the implementation has since been refined and released. Leaving TODO comments in production code misleads contributors about the stability of the code.

### Changes

- src/app/results/[tournamentId]/[groupId]/[memberId]/page.tsx: Remove the three-line TODO comment block: `// TODO: Verify rating algorithm implementation against schack.se's actual code`, `// Current implementation is based on constant names and educated guesses`, and `// Waiting for official implementation details from schack.se`.

---
*Created by [janitor-agent](https://github.com/msvens/janitor-agent)*