### PR TITLE
Redirect Schackfyran and loose-team tournaments to schack.se

### DIFF
--- a/src/app/results/[tournamentId]/[groupId]/page.tsx
+++ b/src/app/results/[tournamentId]/[groupId]/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { PageLayout } from '@/components/layout/PageLayout';
-import { TournamentService, getResultDisplayString, normalizeEloLookupDate, parseLocalDate, getOpponentKind, TournamentDto, TournamentClassDto, TournamentClassGroupDto, TournamentEndResultDto, TournamentRoundResultDto, TournamentState, TeamTournamentEndResultDto } from '@/lib/api';
+import { TournamentService, getResultDisplayString, normalizeEloLookupDate, parseLocalDate, getOpponentKind, TournamentType, isLooseTeamTournament, TournamentDto, TournamentClassDto, TournamentClassGroupDto, TournamentEndResultDto, TournamentRoundResultDto, TournamentState, TeamTournamentEndResultDto } from '@/lib/api';
 import { useLanguage } from '@/context/LanguageContext';
 import { getTranslation } from '@/lib/translations';
 import { useGroupResults, PlayerDateRequest } from '@/context/GroupResultsContext';
@@ -35,6 +35,40 @@ function formatRoundDate(dateStr: string | undefined, locale: string): string {
   if (isNaN(timestamp) || timestamp <= 0) return '';
   const d = new Date(timestamp);
   return d.toLocaleDateString(locale, { day: 'numeric', month: 'numeric', year: '2-digit' });
+}
+
+/**
+ * Notice rendered for tournament formats we can't yet render properly
+ * (Schackfyran team aggregation, loose-team team-name resolution).
+ * Points the user at the official schack.se page for the accurate view.
+ */
+function ExternalResultsNotice({
+  prefix,
+  linkLabel,
+  suffix,
+  url,
+}: {
+  prefix: string;
+  linkLabel: string;
+  suffix: string;
+  url: string;
+}) {
+  return (
+    <div className="rounded-lg border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/20 p-4 mb-6">
+      <p className="text-sm text-gray-700 dark:text-gray-300">
+        {prefix}{' '}
+        <a
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline text-blue-700 dark:text-blue-400 hover:text-blue-900 dark:hover:text-blue-300"
+        >
+          {linkLabel}
+        </a>
+        {suffix.startsWith('.') || suffix.startsWith(',') ? suffix : ` ${suffix}`}
+      </p>
+    </div>
+  );
 }
 
 export default function GroupResultsPage() {
@@ -288,6 +322,23 @@ export default function GroupResultsPage() {
     return today > parseLocalDate(groupEndDate);
   })();
 
+  // Special-format detection — see docs/tournament-formats-and-team-results.md
+  //
+  // Schackfyran (type 9): pairings are individual but results are aggregated
+  // per school/class. Our app can't compute that aggregation yet, so we
+  // replace the standings UI with a link to schack.se for accurate standings.
+  //
+  // Loose team (teamtournamentPlayerListType === 3, e.g. Skol-SM): structurally
+  // a team tournament, but teams aren't bound to a single club, so the
+  // backend's team-table endpoint returns rows with `club: null` and we can't
+  // resolve team names to display labels. We keep showing the (correct)
+  // fixture data but add a banner pointing at schack.se for proper team names.
+  const isSchackfyran = tournament?.type === TournamentType.SCHACKFYRAN;
+  const isLooseTeam = tournament
+    ? isLooseTeamTournament(tournament.teamtournamentPlayerListType)
+    : false;
+  const externalUrl = `https://resultat.schack.se/ShowTournamentServlet?id=${groupId}`;
+
   // Handle row click in final results table - navigate to player detail page
   const handlePlayerClick = (result: TournamentEndResultDto) => {
     if (result.playerInfo?.id && tournamentId && groupId) {
@@ -390,7 +441,20 @@ export default function GroupResultsPage() {
                 )}
               </div>
 
-              {selectedGroup ? (
+              {selectedGroup && (isSchackfyran || isLooseTeam) ? (
+                /* Both Schackfyran and loose-team tournaments: full replacement
+                 * with a notice pointing at schack.se. Schackfyran has no
+                 * client-side team-aggregation logic yet; loose-team standings
+                 * 500 from the upstream API and team names can't be resolved.
+                 * In both cases the alternative (showing the broken or
+                 * misleading data) is worse than just redirecting. */
+                <ExternalResultsNotice
+                  prefix={(isSchackfyran ? t.pages.tournamentResults.externalNotice.schackfyran : t.pages.tournamentResults.externalNotice.looseTeam).prefix}
+                  linkLabel={(isSchackfyran ? t.pages.tournamentResults.externalNotice.schackfyran : t.pages.tournamentResults.externalNotice.looseTeam).linkLabel}
+                  suffix={(isSchackfyran ? t.pages.tournamentResults.externalNotice.schackfyran : t.pages.tournamentResults.externalNotice.looseTeam).suffix}
+                  url={externalUrl}
+                />
+              ) : selectedGroup ? (
                 <>
                   {/* Main Results Table - only render when results are loaded */}
                   {resultsLoading ? (

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -324,6 +324,10 @@ export interface Translations {
       statusOngoing: string;
       statusFinished: string;
       bye: string;
+      externalNotice: {
+        schackfyran: { prefix: string; linkLabel: string; suffix: string };
+        looseTeam: { prefix: string; linkLabel: string; suffix: string };
+      };
       finalResultsTable: {
         pos: string;
         name: string;
@@ -875,6 +879,18 @@ const translations: Record<Language, Translations> = {
         statusOngoing: 'Ongoing',
         statusFinished: 'Finished',
         bye: 'Bye',
+        externalNotice: {
+          schackfyran: {
+            prefix: 'Schackfyran tournaments score by school/class. We don\'t have that team view yet — see the official standings at',
+            linkLabel: 'resultat.schack.se',
+            suffix: '.',
+          },
+          looseTeam: {
+            prefix: 'Team names aren\'t yet available for this format. See the official results at',
+            linkLabel: 'resultat.schack.se',
+            suffix: 'for the proper team names and standings.',
+          },
+        },
         finalResultsTable: {
           pos: 'Pos',
           name: 'Name',
@@ -1424,6 +1440,18 @@ const translations: Record<Language, Translations> = {
         statusOngoing: 'Pågående',
         statusFinished: 'Avslutad',
         bye: 'Frirond',
+        externalNotice: {
+          schackfyran: {
+            prefix: 'Schackfyran-tävlingar poängsätts per skola/klass. Vi har inte den lagvyn än — se den officiella tabellen på',
+            linkLabel: 'resultat.schack.se',
+            suffix: '.',
+          },
+          looseTeam: {
+            prefix: 'Lagnamn är inte tillgängliga än för detta format. Se de officiella resultaten på',
+            linkLabel: 'resultat.schack.se',
+            suffix: 'för korrekta lagnamn och tabeller.',
+          },
+        },
         finalResultsTable: {
           pos: 'Plac',
           name: 'Namn',


### PR DESCRIPTION
## Summary

Two tournament formats currently can't be rendered meaningfully on the results page. Instead of showing broken or misleading data, replace the standings UI with a link to the official `resultat.schack.se` page.

- **Schackfyran (`tournament.type === 9`)** — pairings are individual but meaningful standings are aggregated per school. We don't have client-side aggregation yet. *Also*: per Peter at schack.se, the federation deliberately suppresses individual rows for privacy (Schackfyran kids are typically not tournament-registered), so showing the individual table that the API *does* return would expose data the federation intentionally hides. Full replace is the correct call, not just a stopgap.
- **Loose-team tournaments (`isLooseTeamTournament(teamtournamentPlayerListType)`)** — the team-standings endpoint 500s upstream, and the team round-results endpoint returns structurally correct data whose team labels can't be resolved (no public name lookup for contender IDs yet). Both halves of the page would be broken differently, so we hide both rather than expose either.

Both branches now render a single `ExternalResultsNotice` component with case-specific EN/SV copy. The existing standings/round-by-round rendering is short-circuited via `selectedGroup && (isSchackfyran || isLooseTeam) ? notice : ...`.

Background reference (kept outside this public repo because it quotes the schack.se team by name from email): `~/projects/github.com/msvens/sthlmschack-notes/tournament-formats-and-team-results.md`. That doc captures the full data model, scoring formulas, presentation modes, and a 5-item open-follow-ups list tagged `[SDK]` / `[server]` / `[app]`.

## Test plan

- [ ] `pnpm dev`, open `/results/6535/18056` (Schackfyran) — only the tournament header + notice should render. No standings table, no round-by-round. Toggle SV/EN to verify both copies.
- [ ] Open `/results/6649/18229` (Skol-SM, loose team) — same shape: header + notice only.
- [ ] Open `/results/6685/18320` (regular individual tournament) — sanity regression. No notice should appear; standings + round-by-round render as before.
- [ ] Open any normal team tournament (Allsvenskan / Cupen / Yes2Chess) — no notice; team rendering unchanged.
- [ ] `pnpm check` passes (already green locally).