### PR TITLE
Adopt schack-se-sdk 0.6.0 and refine team-tournament rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
-    "@msvens/schack-se-sdk": "github:msvens/schack-se-sdk#v0.5.0",
+    "@msvens/schack-se-sdk": "github:msvens/schack-se-sdk#v0.6.0",
     "next": "16.2.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
-    "@msvens/schack-se-sdk": "github:msvens/schack-se-sdk#v0.6.0",
+    "@msvens/schack-se-sdk": "github:msvens/schack-se-sdk#v0.6.1",
     "next": "16.2.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0(react@19.2.4)
       '@msvens/schack-se-sdk':
-        specifier: github:msvens/schack-se-sdk#v0.5.0
-        version: https://codeload.github.com/msvens/schack-se-sdk/tar.gz/7270bf3feb57387981c99f45d7f8b010c11c1df1
+        specifier: github:msvens/schack-se-sdk#v0.6.0
+        version: git+https://git@github.com:msvens/schack-se-sdk.git#1a322be7b431d965d82415131ca5fbf662699d16
       next:
         specifier: 16.2.1
         version: 16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -540,9 +540,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@msvens/schack-se-sdk@https://codeload.github.com/msvens/schack-se-sdk/tar.gz/7270bf3feb57387981c99f45d7f8b010c11c1df1':
-    resolution: {tarball: https://codeload.github.com/msvens/schack-se-sdk/tar.gz/7270bf3feb57387981c99f45d7f8b010c11c1df1}
-    version: 0.5.0
+  '@msvens/schack-se-sdk@git+https://git@github.com:msvens/schack-se-sdk.git#1a322be7b431d965d82415131ca5fbf662699d16':
+    resolution: {commit: 1a322be7b431d965d82415131ca5fbf662699d16, repo: git@github.com:msvens/schack-se-sdk.git, type: git}
+    version: 0.6.0
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -3111,7 +3111,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@msvens/schack-se-sdk@https://codeload.github.com/msvens/schack-se-sdk/tar.gz/7270bf3feb57387981c99f45d7f8b010c11c1df1': {}
+  '@msvens/schack-se-sdk@git+https://git@github.com:msvens/schack-se-sdk.git#1a322be7b431d965d82415131ca5fbf662699d16': {}
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0(react@19.2.4)
       '@msvens/schack-se-sdk':
-        specifier: github:msvens/schack-se-sdk#v0.6.0
-        version: git+https://git@github.com:msvens/schack-se-sdk.git#1a322be7b431d965d82415131ca5fbf662699d16
+        specifier: github:msvens/schack-se-sdk#v0.6.1
+        version: https://codeload.github.com/msvens/schack-se-sdk/tar.gz/833932572a336b6e129d62357c9a29f8c7b73b5e
       next:
         specifier: 16.2.1
         version: 16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -540,9 +540,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@msvens/schack-se-sdk@git+https://git@github.com:msvens/schack-se-sdk.git#1a322be7b431d965d82415131ca5fbf662699d16':
-    resolution: {commit: 1a322be7b431d965d82415131ca5fbf662699d16, repo: git@github.com:msvens/schack-se-sdk.git, type: git}
-    version: 0.6.0
+  '@msvens/schack-se-sdk@https://codeload.github.com/msvens/schack-se-sdk/tar.gz/833932572a336b6e129d62357c9a29f8c7b73b5e':
+    resolution: {tarball: https://codeload.github.com/msvens/schack-se-sdk/tar.gz/833932572a336b6e129d62357c9a29f8c7b73b5e}
+    version: 0.6.1
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -3111,7 +3111,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@msvens/schack-se-sdk@git+https://git@github.com:msvens/schack-se-sdk.git#1a322be7b431d965d82415131ca5fbf662699d16': {}
+  '@msvens/schack-se-sdk@https://codeload.github.com/msvens/schack-se-sdk/tar.gz/833932572a336b6e129d62357c9a29f8c7b73b5e': {}
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:

--- a/src/app/results/[tournamentId]/[groupId]/layout.tsx
+++ b/src/app/results/[tournamentId]/[groupId]/layout.tsx
@@ -2,7 +2,7 @@
 
 import { ReactNode, useState, useEffect, useMemo, useCallback } from 'react';
 import { useParams } from 'next/navigation';
-import { ResultsService, TournamentService, formatRatingWithType, getPlayerRatingStrict, getPlayerRatingByRoundType, formatPlayerName, getOpponentKind, TournamentEndResultDto, TournamentRoundResultDto, PlayerInfoDto, TeamTournamentEndResultDto, TournamentDto, RoundDto, isTeamTournament, findTournamentGroup } from '@/lib/api';
+import { ResultsService, TournamentService, formatRatingWithType, getPlayerRatingStrict, getPlayerRatingByRoundType, formatPlayerName, getOpponentKind, TournamentEndResultDto, TournamentRoundResultDto, PlayerInfoDto, TeamTournamentEndResultDto, TournamentDto, RoundDto, isTeamTournament, isTeamPairing, findTournamentGroup } from '@/lib/api';
 import { getTranslation } from '@/lib/translations';
 import { GroupResultsProvider, GroupResultsContextValue, PlayerDateRequest } from '@/context/GroupResultsContext';
 import { useOrganizations } from '@/context/OrganizationsContext';
@@ -43,11 +43,29 @@ export default function GroupResultsLayout({ children }: { children: ReactNode }
   /**
    * Fetch only results data (standings + round results).
    * Used by both initial load and live refresh.
+   *
+   * Tournament-type semantics (see docs/tournament-formats-and-team-results):
+   * - isTeamPairing(type) → team-shaped endpoints (Allsvenskan, Cupen, Yes2Chess).
+   * - isTeamTournament(type) && !isTeamPairing(type) → "individually-paired team
+   *   tournament" (Schackfyran). No team-results endpoint exists upstream; we
+   *   skip fetching entirely and the page surfaces a redirect notice.
+   * - else → individual endpoints.
    */
-  const fetchResults = useCallback(async (isTeam: boolean, isInitialLoad: boolean) => {
+  const fetchResults = useCallback(async (tournamentType: number, isInitialLoad: boolean) => {
+    const isIndividuallyPairedTeam = isTeamTournament(tournamentType) && !isTeamPairing(tournamentType);
+    if (isIndividuallyPairedTeam) {
+      // Nothing to fetch — the page renders the redirect notice instead.
+      setIndividualResults([]);
+      setIndividualRoundResults([]);
+      setTeamResults([]);
+      setTeamRoundResults([]);
+      setLastUpdated(new Date());
+      return;
+    }
+
     const resultsService = new ResultsService();
 
-    if (isTeam) {
+    if (isTeamPairing(tournamentType)) {
       const [teamTableResponse, teamRoundResponse] = await Promise.all([
         resultsService.getTeamTournamentResults(groupId!),
         resultsService.getTeamRoundResults(groupId!)
@@ -127,8 +145,7 @@ export default function GroupResultsLayout({ children }: { children: ReactNode }
         setRoundsMap(newRoundsMap);
       }
 
-      const isTeam = isTeamTournament(tournamentData.type);
-      await fetchResults(isTeam, true);
+      await fetchResults(tournamentData.type, true);
 
     } catch (err) {
       setError('Failed to load results data');
@@ -146,7 +163,7 @@ export default function GroupResultsLayout({ children }: { children: ReactNode }
   const refreshResults = useCallback(async () => {
     if (!tournament || !groupId) return;
     try {
-      await fetchResults(isTeamTournament(tournament.type), false);
+      await fetchResults(tournament.type, false);
     } catch (err) {
       console.error('Error refreshing results:', err);
     }

--- a/src/app/results/[tournamentId]/[groupId]/page.tsx
+++ b/src/app/results/[tournamentId]/[groupId]/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { PageLayout } from '@/components/layout/PageLayout';
-import { TournamentService, getResultDisplayString, normalizeEloLookupDate, parseLocalDate, getOpponentKind, TournamentType, isLooseTeamTournament, TournamentDto, TournamentClassDto, TournamentClassGroupDto, TournamentEndResultDto, TournamentRoundResultDto, TournamentState, TeamTournamentEndResultDto } from '@/lib/api';
+import { TournamentService, getResultDisplayString, normalizeEloLookupDate, parseLocalDate, getOpponentKind, isTeamPairing, isLooseTeamTournament, TournamentDto, TournamentClassDto, TournamentClassGroupDto, TournamentEndResultDto, TournamentRoundResultDto, TournamentState, TeamTournamentEndResultDto } from '@/lib/api';
 import { useLanguage } from '@/context/LanguageContext';
 import { getTranslation } from '@/lib/translations';
 import { useGroupResults, PlayerDateRequest } from '@/context/GroupResultsContext';
@@ -322,18 +322,29 @@ export default function GroupResultsPage() {
     return today > parseLocalDate(groupEndDate);
   })();
 
-  // Special-format detection — see docs/tournament-formats-and-team-results.md
+  // Special-format detection — see the tournament-formats reference notes.
   //
-  // Schackfyran (type 9): pairings are individual but results are aggregated
-  // per school/class. Our app can't compute that aggregation yet, so we
-  // replace the standings UI with a link to schack.se for accurate standings.
+  // Two distinct cases need to surface a notice, with different reasons,
+  // different copy, and different rendering shapes:
   //
-  // Loose team (teamtournamentPlayerListType === 3, e.g. Skol-SM): structurally
-  // a team tournament, but teams aren't bound to a single club, so the
-  // backend's team-table endpoint returns rows with `club: null` and we can't
-  // resolve team names to display labels. We keep showing the (correct)
-  // fixture data but add a banner pointing at schack.se for proper team names.
-  const isSchackfyran = tournament?.type === TournamentType.SCHACKFYRAN;
+  //   1. Individually-paired team tournament (e.g. Schackfyran, type 9):
+  //      identity-wise a team competition, but pairings are individual. No
+  //      team-standings endpoint exists upstream for this format, so the
+  //      layout skips the fetch entirely and the page renders ONLY the
+  //      notice — full replacement.
+  //
+  //   2. Loose team tournament (teamtournamentPlayerListType === 3, e.g.
+  //      Skol-SM): a team tournament where teams aren't bound to a single
+  //      club, so standings rows come back with `club: null` and our display
+  //      falls through to `Org <contenderId>` placeholders. The data itself
+  //      (scores, board pairings) is correct, so we render it but with a
+  //      banner on top explaining that team names aren't available.
+  // Use the context boolean (populated from isTeamTournament(type) in the
+  // layout) and combine with isTeamPairing from the SDK — true for
+  // tournaments that are identity-wise team but use individual pairings.
+  const isIndividuallyPairedTeam = tournament
+    ? isTeamTournament && !isTeamPairing(tournament.type)
+    : false;
   const isLooseTeam = tournament
     ? isLooseTeamTournament(tournament.teamtournamentPlayerListType)
     : false;
@@ -441,21 +452,29 @@ export default function GroupResultsPage() {
                 )}
               </div>
 
-              {selectedGroup && (isSchackfyran || isLooseTeam) ? (
-                /* Both Schackfyran and loose-team tournaments: full replacement
-                 * with a notice pointing at schack.se. Schackfyran has no
-                 * client-side team-aggregation logic yet; loose-team standings
-                 * 500 from the upstream API and team names can't be resolved.
-                 * In both cases the alternative (showing the broken or
-                 * misleading data) is worse than just redirecting. */
+              {selectedGroup && isIndividuallyPairedTeam ? (
+                /* Individually-paired team tournament (Schackfyran today):
+                 * no team-standings endpoint exists upstream, so the layout
+                 * skips the fetch entirely and we always show this notice. */
                 <ExternalResultsNotice
-                  prefix={(isSchackfyran ? t.pages.tournamentResults.externalNotice.schackfyran : t.pages.tournamentResults.externalNotice.looseTeam).prefix}
-                  linkLabel={(isSchackfyran ? t.pages.tournamentResults.externalNotice.schackfyran : t.pages.tournamentResults.externalNotice.looseTeam).linkLabel}
-                  suffix={(isSchackfyran ? t.pages.tournamentResults.externalNotice.schackfyran : t.pages.tournamentResults.externalNotice.looseTeam).suffix}
+                  prefix={t.pages.tournamentResults.externalNotice.individuallyPairedTeam.prefix}
+                  linkLabel={t.pages.tournamentResults.externalNotice.individuallyPairedTeam.linkLabel}
+                  suffix={t.pages.tournamentResults.externalNotice.individuallyPairedTeam.suffix}
                   url={externalUrl}
                 />
               ) : selectedGroup ? (
                 <>
+                  {/* Loose-team banner above the rendered content. The data
+                   * itself is accurate; only the team labels are degraded
+                   * (placeholder Org IDs). */}
+                  {isLooseTeam && (
+                    <ExternalResultsNotice
+                      prefix={t.pages.tournamentResults.externalNotice.looseTeam.prefix}
+                      linkLabel={t.pages.tournamentResults.externalNotice.looseTeam.linkLabel}
+                      suffix={t.pages.tournamentResults.externalNotice.looseTeam.suffix}
+                      url={externalUrl}
+                    />
+                  )}
                   {/* Main Results Table - only render when results are loaded */}
                   {resultsLoading ? (
                     // Don't show anything while loading - prevents flashing wrong state

--- a/src/app/results/[tournamentId]/[groupId]/team/[teamId]/page.tsx
+++ b/src/app/results/[tournamentId]/[groupId]/team/[teamId]/page.tsx
@@ -11,15 +11,25 @@ import { TeamDetailMatches } from '@/components/results/TeamDetailMatches';
 import { Link } from '@/components/Link';
 
 /**
- * Parse teamId string to extract clubId and teamNumber
- * Format: "{clubId}-{teamNumber}" e.g., "12345-1"
+ * Parse teamId string to extract contender and teamNumber.
+ *
+ * URL format: "{contenderId}-{teamNumber}" (e.g. "16322-1", "16322-2", or
+ * "16322--1"). The contenderId is always a positive integer; the teamNumber
+ * can be:
+ *   - Positive (1, 2, …) for clubs running multiple teams in the tournament.
+ *   - `-1` as a sentinel for "no team number" — used by single-team-per-club
+ *     entries and by loose-team tournaments (Skol-SM etc.) where the team
+ *     isn't bound to a numbered roster slot.
+ *
+ * We split on the FIRST '-' (not all of them) so the trailing `-1` reassembles
+ * correctly. `parseInt` handles the leading minus.
  */
 function parseTeamId(teamId: string): { clubId: number; teamNumber: number } | null {
-  const parts = teamId.split('-');
-  if (parts.length !== 2) return null;
+  const dashIndex = teamId.indexOf('-');
+  if (dashIndex < 1) return null;
 
-  const clubId = parseInt(parts[0], 10);
-  const teamNumber = parseInt(parts[1], 10);
+  const clubId = parseInt(teamId.slice(0, dashIndex), 10);
+  const teamNumber = parseInt(teamId.slice(dashIndex + 1), 10);
 
   if (isNaN(clubId) || isNaN(teamNumber)) return null;
 

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -325,7 +325,7 @@ export interface Translations {
       statusFinished: string;
       bye: string;
       externalNotice: {
-        schackfyran: { prefix: string; linkLabel: string; suffix: string };
+        individuallyPairedTeam: { prefix: string; linkLabel: string; suffix: string };
         looseTeam: { prefix: string; linkLabel: string; suffix: string };
       };
       finalResultsTable: {
@@ -880,15 +880,15 @@ const translations: Record<Language, Translations> = {
         statusFinished: 'Finished',
         bye: 'Bye',
         externalNotice: {
-          schackfyran: {
-            prefix: 'Schackfyran tournaments score by school/class. We don\'t have that team view yet — see the official standings at',
+          individuallyPairedTeam: {
+            prefix: 'This is a team tournament with individual pairings. The team standings aren\'t available from the data source for this format — see the official results at',
             linkLabel: 'resultat.schack.se',
             suffix: '.',
           },
           looseTeam: {
-            prefix: 'Team names aren\'t yet available for this format. See the official results at',
+            prefix: 'Team names aren\'t available yet for this format — they appear as `Org <id>` below. See the official results at',
             linkLabel: 'resultat.schack.se',
-            suffix: 'for the proper team names and standings.',
+            suffix: 'for the proper names.',
           },
         },
         finalResultsTable: {
@@ -1441,15 +1441,15 @@ const translations: Record<Language, Translations> = {
         statusFinished: 'Avslutad',
         bye: 'Frirond',
         externalNotice: {
-          schackfyran: {
-            prefix: 'Schackfyran-tävlingar poängsätts per skola/klass. Vi har inte den lagvyn än — se den officiella tabellen på',
+          individuallyPairedTeam: {
+            prefix: 'Detta är en lagturnering med individuell lottning. Lagtabellen är inte tillgänglig från datakällan för detta format — se de officiella resultaten på',
             linkLabel: 'resultat.schack.se',
             suffix: '.',
           },
           looseTeam: {
-            prefix: 'Lagnamn är inte tillgängliga än för detta format. Se de officiella resultaten på',
+            prefix: 'Lagnamn är inte tillgängliga ännu för detta format — de visas som `Org <id>` nedan. Se de officiella resultaten på',
             linkLabel: 'resultat.schack.se',
-            suffix: 'för korrekta lagnamn och tabeller.',
+            suffix: 'för korrekta namn.',
           },
         },
         finalResultsTable: {


### PR DESCRIPTION
## Summary

Bumps the SDK and reshapes the team-tournament rendering on the results page to match the model your friend at schack.se laid out.

### SDK 0.6.0
- `isTeamTournament(type)` now returns true for `{2, 6, 8, 9}` (was `{2, 6, 8}`). Identity-wise team tournament — includes Schackfyran. Use this for user-facing classification (player profile tabs, calendar filters).
- New `isTeamPairing(type)` keeps the old `{2, 6, 8}` set. "Are pairings team-vs-team?" Use this for data-shape decisions (which endpoint, which renderer).
- New `isSchackfyran(type)`, `isSchackfyranLike(type, pointSystem)`, plus `PairingSystem` and `Schack4anTeamPointSystem` constants.

### App-side: two distinct degraded-rendering paths

| Format | Predicate | Behaviour |
|---|---|---|
| Individually-paired team (Schackfyran today) | `isTeamTournament(type) && !isTeamPairing(type)` | **Full replace** — layout skips the fetch entirely, page shows only the redirect notice. No team-table endpoint exists upstream for this format, and the federation deliberately hides individual S4 rows for privacy. |
| Loose team | `isLooseTeamTournament(playerListType)` | **Banner above + content** — standings now load 200 with every row `club: null` (schack.se's null-club fix landed mid-May). Render the table; existing `getClubName(contenderId)` fallback shows `Org <id>` for every team. Banner above explains why names are placeholders. |

The free-side benefit of the SDK upgrade: player profile and calendar filters automatically reclassify Schackfyran participations as team — no code change in those files needed.

### Latent bug fix: team URL parser

`team/[teamId]/page.tsx` parsed URLs of shape `{contenderId}-{teamNumber}`. For single-team-per-club entries and loose teams, `teamNumber === -1`, producing `team/16322--1`. The old `split('-')` returned three parts and bailed; the parser now uses `indexOf('-')` + slice so the trailing `-1` reassembles as a negative number. Surfaced only now because loose-team standings just became clickable.

## Test plan

- [ ] `pnpm dev`, open `/results/6535/18056` (Schackfyran). Header + notice only; no standings, no round-by-round. Confirm SV/EN copy.
- [ ] `/results/6649/18229` (Skol-SM, loose team). Banner above + standings table + round-by-round below. All team labels read as `Org <id>`. Confirm SV/EN copy.
- [ ] Click a team row in `/results/6649/18229` standings → navigates to `/results/6649/18229/team/16xxx--1` and the page renders (no longer "Invalid team ID format" error).
- [ ] `/results/6685/18320` (regular individual tournament) — no notice, individual rendering, regression-clean.
- [ ] Any normal team tournament (Allsvenskan / Cupen / Yes2Chess) — no notice, team rendering, regression-clean.
- [ ] Player profile for someone who's played a Schackfyran event — that participation now appears in the **Team** tab (was Individual under SDK 0.5.0).
- [ ] `pnpm check` passes (already green locally).

## Reference

`~/projects/github.com/msvens/sthlmschack-notes/tournament-formats-and-team-results.md` — kept outside this public repo because it quotes the schack.se team by name from email. Updated in lockstep with this PR: corrected the `SCHOOL_SM` (type 5) entry (it's individual, not team — real team Skol-SM is type 2 + playerListType 3), updated the app-side behaviour section, and documented the URL parser gotcha.