### PR TITLE
Add week/month calendar views to the calendar page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "sthlmschack-reimagined",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@10.29.3",
   "scripts": {
     "dev": "next dev -p 3001",
     "build": "next build",

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -4,6 +4,8 @@ import { useState, useEffect, useMemo } from 'react';
 import { PageLayout } from "@/components/layout/PageLayout";
 import { PageTitle } from "@/components/PageTitle";
 import { TournamentList } from "@/components/TournamentList";
+import { CalendarView } from "@/components/calendar/CalendarView";
+import { getSavedTab, setSavedTab, type CalendarTab } from "@/components/calendar/calendarPrefs";
 import { DistrictFilter, DistrictCount } from "@/components/DistrictFilter";
 import { TournamentCategoryFilter, TournamentTypeFilter, TournamentStateFilter } from "@/components/filters";
 import { useOrganizations } from "@/context/OrganizationsContext";
@@ -24,6 +26,22 @@ export default function CalendarPage() {
   const { language } = useLanguage();
   const t = getTranslation(language);
   const { getDistrictIdForOrganizer } = useOrganizations();
+
+  const [activeTab, setActiveTab] = useState<CalendarTab>('calendar');
+
+  // Restore the last-used tab on mount (default render stays SSR-safe).
+  useEffect(() => {
+    const restore = () => {
+      const saved = getSavedTab();
+      if (saved) setActiveTab(saved);
+    };
+    restore();
+  }, []);
+
+  const selectTab = (tab: CalendarTab) => {
+    setActiveTab(tab);
+    setSavedTab(tab);
+  };
 
   const [allTournaments, setAllTournaments] = useState<TournamentDto[]>([]);
   const [loading, setLoading] = useState(true);
@@ -182,12 +200,38 @@ export default function CalendarPage() {
         />
       </div>
 
-      <TournamentList
-        tournaments={filteredTournaments}
-        loading={loading}
-        error={error || undefined}
-        language={language}
-      />
+      {/* View tabs: Calendar / List */}
+      <div className="mb-4 flex border-b border-gray-200 dark:border-gray-700">
+        {(['calendar', 'list'] as const).map((tab) => (
+          <button
+            key={tab}
+            onClick={() => selectTab(tab)}
+            className={`px-4 py-3 text-sm font-medium whitespace-nowrap transition-colors ${
+              activeTab === tab
+                ? 'border-b-2 text-blue-600 dark:text-blue-400 border-blue-600 dark:border-blue-400'
+                : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
+            }`}
+          >
+            {t.pages.calendar.tabs[tab]}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === 'list' ? (
+        <TournamentList
+          tournaments={filteredTournaments}
+          loading={loading}
+          error={error || undefined}
+          language={language}
+        />
+      ) : (
+        <CalendarView
+          tournaments={filteredTournaments}
+          language={language}
+          loading={loading}
+          error={error || undefined}
+        />
+      )}
     </PageLayout>
   );
 }

--- a/src/components/calendar/CalendarNav.tsx
+++ b/src/components/calendar/CalendarNav.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { type Language } from '@/context/LanguageContext';
+import { getTranslation } from '@/lib/translations';
+
+interface CalendarNavProps {
+  title: string;
+  language: Language;
+  view: 'week' | 'month';
+  onViewChange: (view: 'week' | 'month') => void;
+  canGoPrev: boolean;
+  canGoNext: boolean;
+  onPrev: () => void;
+  onNext: () => void;
+  onToday: () => void;
+  onEarliest: () => void;
+  onLatest: () => void;
+}
+
+const iconBtn =
+  'flex h-8 w-8 items-center justify-center rounded-md border border-gray-200 text-gray-600 transition-colors hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800';
+
+export function CalendarNav({
+  title,
+  language,
+  view,
+  onViewChange,
+  canGoPrev,
+  canGoNext,
+  onPrev,
+  onNext,
+  onToday,
+  onEarliest,
+  onLatest,
+}: CalendarNavProps) {
+  const t = getTranslation(language);
+  const nav = t.pages.calendar.nav;
+  const views = t.pages.calendar.views;
+
+  return (
+    <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+      {/* Navigation cluster */}
+      <div className="flex items-center gap-1">
+        <button type="button" onClick={onEarliest} disabled={!canGoPrev} title={nav.earliest} aria-label={nav.earliest} className={iconBtn}>
+          «
+        </button>
+        <button type="button" onClick={onPrev} disabled={!canGoPrev} title={nav.prev} aria-label={nav.prev} className={iconBtn}>
+          ‹
+        </button>
+        <button
+          type="button"
+          onClick={onToday}
+          className="rounded-md border border-gray-200 px-2.5 py-1 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-100 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+        >
+          {nav.today}
+        </button>
+        <button type="button" onClick={onNext} disabled={!canGoNext} title={nav.next} aria-label={nav.next} className={iconBtn}>
+          ›
+        </button>
+        <button type="button" onClick={onLatest} disabled={!canGoNext} title={nav.latest} aria-label={nav.latest} className={iconBtn}>
+          »
+        </button>
+      </div>
+
+      {/* Period title */}
+      <h2 className="order-last w-full truncate text-center text-sm font-semibold capitalize text-gray-900 sm:order-none sm:w-auto sm:flex-1 sm:text-base dark:text-gray-100">
+        {title}
+      </h2>
+
+      {/* View selector */}
+      <select
+        value={view}
+        onChange={(e) => onViewChange(e.target.value as 'week' | 'month')}
+        aria-label={views.month}
+        className="shrink-0 rounded-md border border-gray-200 bg-white px-2 py-1 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+      >
+        <option value="week">{views.week}</option>
+        <option value="month">{views.month}</option>
+      </select>
+    </div>
+  );
+}

--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { type Language } from '@/context/LanguageContext';
+import type { TournamentDto } from '@/lib/api';
+import { getTranslation } from '@/lib/translations';
+import {
+  addDays,
+  addMonths,
+  buildMonthRows,
+  buildWeekRow,
+  getEventDateBounds,
+  toDayNumber,
+} from '@/lib/utils/calendarLayout';
+import { CalendarNav } from './CalendarNav';
+import { MonthView } from './MonthView';
+import { WeekView } from './WeekView';
+import {
+  getSavedAnchor,
+  getSavedView,
+  setSavedAnchor,
+  setSavedView,
+  type CalendarViewMode,
+} from './calendarPrefs';
+
+interface CalendarViewProps {
+  tournaments: TournamentDto[];
+  language: Language;
+  loading?: boolean;
+  error?: string;
+}
+
+const monthKey = (d: Date) => d.getFullYear() * 12 + d.getMonth();
+const weekStartNumber = (d: Date) => toDayNumber(addDays(d, -((d.getDay() + 6) % 7)));
+
+export function CalendarView({ tournaments, language, loading, error }: CalendarViewProps) {
+  const t = getTranslation(language);
+  const locale = language === 'sv' ? 'sv-SE' : 'en-US';
+  const [view, setView] = useState<CalendarViewMode>('month');
+  const [anchor, setAnchor] = useState<Date>(() => new Date());
+
+  // Restore saved view + anchor on mount (default render stays SSR-safe).
+  useEffect(() => {
+    const restore = () => {
+      const savedView = getSavedView();
+      if (savedView) setView(savedView);
+      const savedAnchor = getSavedAnchor();
+      if (savedAnchor) setAnchor(savedAnchor);
+    };
+    restore();
+  }, []);
+
+  // Persist on user action (not via effects, to avoid clobbering on mount).
+  const changeView = (next: CalendarViewMode) => {
+    setView(next);
+    setSavedView(next);
+  };
+  const applyAnchor = (next: Date) => {
+    setAnchor(next);
+    setSavedAnchor(next);
+  };
+
+  const todayDayNumber = useMemo(() => toDayNumber(new Date()), []);
+  const bounds = useMemo(() => getEventDateBounds(tournaments), [tournaments]);
+
+  // Mon–Sun short labels derived from a known Monday (2024-01-01).
+  const weekdayLabels = useMemo(() => {
+    const fmt = new Intl.DateTimeFormat(locale, { weekday: 'short' });
+    const monday = new Date(2024, 0, 1);
+    return Array.from({ length: 7 }, (_, i) => fmt.format(addDays(monday, i)));
+  }, [locale]);
+
+  const monthRows = useMemo(
+    () => (view === 'month' ? buildMonthRows(anchor, tournaments, todayDayNumber) : []),
+    [view, anchor, tournaments, todayDayNumber],
+  );
+  const weekRow = useMemo(
+    () => (view === 'week' ? buildWeekRow(anchor, tournaments, todayDayNumber) : null),
+    [view, anchor, tournaments, todayDayNumber],
+  );
+
+  const title = useMemo(() => {
+    if (view === 'month') {
+      return new Intl.DateTimeFormat(locale, { month: 'long', year: 'numeric' }).format(anchor);
+    }
+    const weekStart = addDays(anchor, -((anchor.getDay() + 6) % 7));
+    const weekEnd = addDays(weekStart, 6);
+    const dayMonth = new Intl.DateTimeFormat(locale, { day: 'numeric', month: 'short' });
+    const full = new Intl.DateTimeFormat(locale, { day: 'numeric', month: 'short', year: 'numeric' });
+    return `${dayMonth.format(weekStart)} – ${full.format(weekEnd)}`;
+  }, [view, anchor, locale]);
+
+  let canGoPrev = false;
+  let canGoNext = false;
+  if (bounds) {
+    if (view === 'month') {
+      canGoPrev = monthKey(anchor) > monthKey(bounds.earliest);
+      canGoNext = monthKey(anchor) < monthKey(bounds.latest);
+    } else {
+      canGoPrev = weekStartNumber(anchor) > weekStartNumber(bounds.earliest);
+      canGoNext = weekStartNumber(anchor) < weekStartNumber(bounds.latest);
+    }
+  }
+
+  const goPrev = () => applyAnchor(view === 'month' ? addMonths(anchor, -1) : addDays(anchor, -7));
+  const goNext = () => applyAnchor(view === 'month' ? addMonths(anchor, 1) : addDays(anchor, 7));
+  const goToday = () => applyAnchor(new Date());
+  const goEarliest = () => bounds && applyAnchor(bounds.earliest);
+  const goLatest = () => bounds && applyAnchor(bounds.latest);
+
+  return (
+    <div>
+      <CalendarNav
+        title={title}
+        language={language}
+        view={view}
+        onViewChange={changeView}
+        canGoPrev={canGoPrev}
+        canGoNext={canGoNext}
+        onPrev={goPrev}
+        onNext={goNext}
+        onToday={goToday}
+        onEarliest={goEarliest}
+        onLatest={goLatest}
+      />
+
+      {loading ? (
+        <div className="py-12 text-center text-gray-500 dark:text-gray-400">
+          {t.pages.calendar.tournamentList.loading}
+        </div>
+      ) : error ? (
+        <div className="py-12 text-center text-red-600 dark:text-red-400">{error}</div>
+      ) : view === 'month' ? (
+        <MonthView rows={monthRows} tournaments={tournaments} language={language} weekdayLabels={weekdayLabels} />
+      ) : weekRow ? (
+        <WeekView row={weekRow} language={language} weekdayLabels={weekdayLabels} />
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/calendar/DayEventsPopover.tsx
+++ b/src/components/calendar/DayEventsPopover.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { useEffect, useLayoutEffect, useRef } from 'react';
+import { Link } from '@/components/Link';
+import { useOrganizations } from '@/context/OrganizationsContext';
+import { type Language } from '@/context/LanguageContext';
+import { parseLocalDate, type TournamentDto } from '@/lib/api';
+import { getTranslation } from '@/lib/translations';
+import { getTournamentTypeKey } from '@/lib/utils/tournamentFilters';
+import { getTypeSwatchClasses } from './calendarColors';
+
+interface DayEventsPopoverProps {
+  date: Date;
+  events: TournamentDto[];
+  language: Language;
+  onClose: () => void;
+}
+
+/**
+ * Lightweight popover listing a day's events with full detail. Anchored inside
+ * the (relatively positioned) day cell; closes on outside-click and Escape.
+ * After mount it measures itself against the viewport and flips up/left so it
+ * never opens off-screen.
+ */
+export function DayEventsPopover({ date, events, language, onClose }: DayEventsPopoverProps) {
+  const t = getTranslation(language);
+  const { getOrganizerName } = useOrganizations();
+  const ref = useRef<HTMLDivElement>(null);
+
+  const locale = language === 'sv' ? 'sv-SE' : 'en-US';
+  const headerFmt = new Intl.DateTimeFormat(locale, { weekday: 'long', day: 'numeric', month: 'long' });
+  const rangeFmt = new Intl.DateTimeFormat(locale, { day: 'numeric', month: 'short', year: 'numeric' });
+  const typeLabels = t.components.tournamentTypeFilter;
+
+  // Measure against the viewport and place the popover directly on the node
+  // (no React state → no cascading renders) so it never opens off-screen.
+  // The decision uses the anchor's geometry + the popover's own size, so it
+  // doesn't depend on the current placement (no flip ping-pong).
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const anchor = (el.parentElement ?? el).getBoundingClientRect();
+    const margin = 8;
+    const roomBelow = window.innerHeight - anchor.bottom;
+    const dropUp = roomBelow < el.offsetHeight + margin && anchor.top > roomBelow;
+    const pinRight = anchor.left + el.offsetWidth + margin > window.innerWidth;
+
+    el.style.top = dropUp ? 'auto' : '100%';
+    el.style.bottom = dropUp ? '100%' : 'auto';
+    el.style.marginTop = dropUp ? '0' : '4px';
+    el.style.marginBottom = dropUp ? '4px' : '0';
+    el.style.left = pinRight ? 'auto' : '0';
+    el.style.right = pinRight ? '0' : 'auto';
+  }, [events, language]);
+
+  useEffect(() => {
+    function onPointerDown(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    }
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    document.addEventListener('mousedown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [onClose]);
+
+  function formatRange(tournament: TournamentDto): string {
+    const start = rangeFmt.format(parseLocalDate(tournament.start));
+    if (!tournament.end || tournament.end === tournament.start) return start;
+    return `${start} – ${rangeFmt.format(parseLocalDate(tournament.end))}`;
+  }
+
+  function typeLabel(type: number): string {
+    const key = getTournamentTypeKey(type) as keyof typeof typeLabels;
+    return key in typeLabels ? typeLabels[key] : '';
+  }
+
+  return (
+    <div
+      ref={ref}
+      onClick={(e) => e.stopPropagation()}
+      style={{ top: '100%', left: 0, marginTop: 4 }}
+      className="absolute z-30 w-64 max-w-[80vw] rounded-lg border border-gray-200 bg-white p-3 shadow-lg dark:border-gray-700 dark:bg-gray-800"
+    >
+      <div className="mb-2 text-sm font-semibold capitalize text-gray-900 dark:text-gray-100">
+        {headerFmt.format(date)}
+      </div>
+
+      <ul className="flex max-h-80 flex-col gap-3 overflow-y-auto">
+        {events.map((tournament) => (
+          <li key={tournament.id} className="flex gap-2">
+            <span
+              aria-hidden
+              className={`mt-1 h-2.5 w-2.5 shrink-0 rounded-full ${getTypeSwatchClasses(tournament.type)}`}
+            />
+            <div className="min-w-0 flex-1">
+              <Link href={`/results/${tournament.id}`} className="block truncate text-sm font-medium">
+                {tournament.name}
+              </Link>
+              <dl className="mt-1 space-y-0.5 text-xs text-gray-600 dark:text-gray-400">
+                <div className="flex gap-1">
+                  <dt className="shrink-0 font-medium">{t.pages.calendar.dayDetails.organizer}:</dt>
+                  <dd className="truncate">{getOrganizerName(tournament.orgType, tournament.orgNumber)}</dd>
+                </div>
+                {tournament.city && (
+                  <div className="flex gap-1">
+                    <dt className="shrink-0 font-medium">{t.pages.calendar.dayDetails.city}:</dt>
+                    <dd className="truncate">{tournament.city}</dd>
+                  </div>
+                )}
+                {typeLabel(tournament.type) && (
+                  <div className="flex gap-1">
+                    <dt className="shrink-0 font-medium">{t.pages.calendar.dayDetails.type}:</dt>
+                    <dd className="truncate">{typeLabel(tournament.type)}</dd>
+                  </div>
+                )}
+                <div className="flex gap-1">
+                  <dt className="shrink-0 font-medium">{t.pages.calendar.dayDetails.dateRange}:</dt>
+                  <dd className="truncate">{formatRange(tournament)}</dd>
+                </div>
+              </dl>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/calendar/EventBar.tsx
+++ b/src/components/calendar/EventBar.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import type { TournamentDto } from '@/lib/api';
+import { getTranslation } from '@/lib/translations';
+import type { PositionedSegment } from '@/lib/utils/calendarLayout';
+import { getTypeBarClasses } from './calendarColors';
+
+interface EventBarProps {
+  segment: PositionedSegment;
+  /** Day number of the first cell in the row (for anchoring the popover). */
+  rowStartDayNumber: number;
+  /** Pixel offset of the bar's top within the row. */
+  top: number;
+  /** Bar height in pixels. */
+  height: number;
+  language: 'sv' | 'en';
+  /** Fired with the clicked tournament and the day to anchor the popover to. */
+  onSelect: (tournament: TournamentDto, dayNumber: number) => void;
+}
+
+/**
+ * A single positioned event bar (or start-only marker) within a calendar row.
+ * Position is computed as a percentage of the 7-column row so it aligns exactly
+ * with the day-cell grid behind it.
+ */
+export function EventBar({ segment, rowStartDayNumber, top, height, language, onSelect }: EventBarProps) {
+  const t = getTranslation(language);
+  const { tournament, colOffset, colSpan, continuesLeft, continuesRight, startOnly } = segment;
+
+  const leftPct = (colOffset / 7) * 100;
+  const widthPct = (colSpan / 7) * 100;
+
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        onSelect(tournament, rowStartDayNumber + colOffset);
+      }}
+      title={startOnly ? `${tournament.name} (${t.pages.calendar.longerEvent})` : tournament.name}
+      style={{
+        position: 'absolute',
+        top,
+        height,
+        left: `calc(${leftPct}% + 2px)`,
+        width: `calc(${widthPct}% - 4px)`,
+      }}
+      className={`flex items-center gap-0.5 overflow-hidden rounded border px-1 text-left text-[10px] leading-none transition-opacity hover:opacity-80 sm:text-xs ${getTypeBarClasses(
+        tournament.type,
+      )}`}
+    >
+      {continuesLeft && <span aria-hidden className="shrink-0">◀</span>}
+      {startOnly && <span aria-hidden className="shrink-0 opacity-70">•</span>}
+      <span className="truncate">{tournament.name}</span>
+      {continuesRight && <span aria-hidden className="ml-auto shrink-0">▶</span>}
+    </button>
+  );
+}

--- a/src/components/calendar/MonthView.tsx
+++ b/src/components/calendar/MonthView.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { type Language } from '@/context/LanguageContext';
+import type { TournamentDto } from '@/lib/api';
+import { getTranslation } from '@/lib/translations';
+import {
+  MONTH_MAX_LANES,
+  tournamentsForDay,
+  type PackedRow,
+} from '@/lib/utils/calendarLayout';
+import { DayEventsPopover } from './DayEventsPopover';
+import { EventBar } from './EventBar';
+
+interface MonthViewProps {
+  rows: PackedRow[];
+  tournaments: TournamentDto[];
+  language: Language;
+  /** Localized Mon–Sun short weekday labels. */
+  weekdayLabels: string[];
+}
+
+const HEADER_H = 24; // px reserved for the date number
+const LANE_H = 20; // px per bar lane
+const BAR_H = 17; // px bar height
+const PAD_B = 6; // px bottom padding
+const MIN_ROW = 96; // px minimum row height — keeps a calendar-like grid even when sparse
+
+export function MonthView({ rows, tournaments, language, weekdayLabels }: MonthViewProps) {
+  const t = getTranslation(language);
+  // `tournamentId: null` → show the whole day; otherwise show just that event.
+  const [open, setOpen] = useState<{ day: number; tournamentId: number | null } | null>(null);
+
+  const openDate = useMemo(() => {
+    if (!open) return null;
+    for (const row of rows) {
+      const cell = row.cells.find((c) => c.dayNumber === open.day);
+      if (cell) return cell.date;
+    }
+    return null;
+  }, [open, rows]);
+
+  const openEvents = useMemo(() => {
+    if (!open) return [];
+    if (open.tournamentId !== null) {
+      const match = tournaments.find((tt) => tt.id === open.tournamentId);
+      return match ? [match] : [];
+    }
+    return tournamentsForDay(tournaments, open.day);
+  }, [open, tournaments]);
+
+  return (
+    <div className="rounded-lg border border-gray-200 dark:border-gray-700">
+      {/* Weekday header */}
+      <div className="grid grid-cols-7 rounded-t-lg border-b border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-800/50">
+        {weekdayLabels.map((label) => (
+          <div
+            key={label}
+            className="px-1 py-1.5 text-center text-[10px] font-medium uppercase tracking-wide text-gray-500 sm:text-xs dark:text-gray-400"
+          >
+            {label}
+          </div>
+        ))}
+      </div>
+
+      {/* Week rows */}
+      {rows.map((row, rowIndex) => {
+        const shownLanes = Math.min(row.maxLanes, MONTH_MAX_LANES);
+        const rowStart = row.cells[0].dayNumber;
+
+        // Per-cell overflow: events drawn on the day minus the bars we render.
+        const overflowByCol = row.cells.map((cell) => {
+          const total = tournamentsForDay(tournaments, cell.dayNumber).length;
+          const shown = row.segments.filter(
+            (s) =>
+              s.laneIndex < MONTH_MAX_LANES &&
+              cell.dayNumber >= rowStart + s.colOffset &&
+              cell.dayNumber < rowStart + s.colOffset + s.colSpan,
+          ).length;
+          return Math.max(0, total - shown);
+        });
+        const hasOverflow = overflowByCol.some((n) => n > 0);
+
+        const minHeight = Math.max(
+          MIN_ROW,
+          HEADER_H + shownLanes * LANE_H + (hasOverflow ? LANE_H : 0) + PAD_B,
+        );
+
+        return (
+          <div
+            key={rowIndex}
+            className="relative grid grid-cols-7"
+            style={{ minHeight }}
+          >
+            {/* Day-cell backgrounds */}
+            {row.cells.map((cell, colIndex) => {
+              const dayEvents = tournamentsForDay(tournaments, cell.dayNumber);
+              const clickable = dayEvents.length > 0;
+              return (
+                <div
+                  key={cell.dayNumber}
+                  onClick={clickable ? () => setOpen({ day: cell.dayNumber, tournamentId: null }) : undefined}
+                  className={`relative border-b border-r border-gray-200 last:border-r-0 dark:border-gray-700 ${
+                    colIndex === 6 ? 'border-r-0' : ''
+                  } ${cell.inCurrentMonth ? '' : 'bg-gray-50/60 dark:bg-gray-800/30'} ${
+                    clickable ? 'cursor-pointer hover:bg-blue-50/50 dark:hover:bg-blue-900/10' : ''
+                  }`}
+                >
+                  <div className="px-1.5 pt-1">
+                    <span
+                      className={`inline-flex h-5 min-w-5 items-center justify-center rounded-full px-1 text-[10px] sm:text-xs ${
+                        cell.isToday
+                          ? 'bg-blue-600 font-semibold text-white dark:bg-blue-500'
+                          : cell.inCurrentMonth
+                            ? 'text-gray-700 dark:text-gray-300'
+                            : 'text-gray-400 dark:text-gray-600'
+                      }`}
+                    >
+                      {cell.date.getDate()}
+                    </span>
+                  </div>
+
+                  {/* "+N more" overflow affordance */}
+                  {overflowByCol[colIndex] > 0 && (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setOpen({ day: cell.dayNumber, tournamentId: null });
+                      }}
+                      style={{ top: HEADER_H + shownLanes * LANE_H }}
+                      className="absolute left-1 text-[10px] font-medium text-gray-500 hover:text-blue-600 sm:text-[11px] dark:text-gray-400 dark:hover:text-blue-400"
+                    >
+                      {t.pages.calendar.moreEvents.replace('{count}', String(overflowByCol[colIndex]))}
+                    </button>
+                  )}
+
+                  {/* Popover anchored to the opened cell */}
+                  {open?.day === cell.dayNumber && openDate && (
+                    <DayEventsPopover
+                      date={openDate}
+                      events={openEvents}
+                      language={language}
+                      onClose={() => setOpen(null)}
+                    />
+                  )}
+                </div>
+              );
+            })}
+
+            {/* Event bars overlay */}
+            {row.segments
+              .filter((s) => s.laneIndex < MONTH_MAX_LANES)
+              .map((segment) => (
+                <EventBar
+                  key={`${segment.tournament.id}-${segment.colOffset}`}
+                  segment={segment}
+                  rowStartDayNumber={rowStart}
+                  top={HEADER_H + segment.laneIndex * LANE_H}
+                  height={BAR_H}
+                  language={language}
+                  onSelect={(tournament, dayNumber) => setOpen({ day: dayNumber, tournamentId: tournament.id })}
+                />
+              ))}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/calendar/WeekView.tsx
+++ b/src/components/calendar/WeekView.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { useState } from 'react';
+import { Link } from '@/components/Link';
+import { type Language } from '@/context/LanguageContext';
+import { useOrganizations } from '@/context/OrganizationsContext';
+import { useIsMobile } from '@/hooks';
+import { parseLocalDate, type TournamentDto } from '@/lib/api';
+import { getTranslation } from '@/lib/translations';
+import { getTournamentTypeKey } from '@/lib/utils/tournamentFilters';
+import { type PackedRow } from '@/lib/utils/calendarLayout';
+import { getTypeBarClasses } from './calendarColors';
+import { DayEventsPopover } from './DayEventsPopover';
+
+interface WeekViewProps {
+  row: PackedRow;
+  language: Language;
+  /** Localized Mon–Sun short weekday labels. */
+  weekdayLabels: string[];
+}
+
+export function WeekView({ row, weekdayLabels, language }: WeekViewProps) {
+  const t = getTranslation(language);
+  const { getOrganizerName } = useOrganizations();
+  const isMobile = useIsMobile();
+  const [open, setOpen] = useState<{ tournamentId: number; colOffset: number } | null>(null);
+
+  const locale = language === 'sv' ? 'sv-SE' : 'en-US';
+  const rangeFmt = new Intl.DateTimeFormat(locale, { day: 'numeric', month: 'short' });
+  const typeLabels = t.components.tournamentTypeFilter;
+
+  // Keep a calendar-like minimum height; any leftover space sits below the
+  // events (not inside the cards, which are now content-height).
+  const minBand = isMobile ? 220 : 300;
+  const rowStart = row.cells[0].dayNumber;
+
+  function typeLabel(type: number): string {
+    const key = getTournamentTypeKey(type) as keyof typeof typeLabels;
+    return key in typeLabels ? typeLabels[key] : '';
+  }
+
+  function formatRange(tournament: TournamentDto): string {
+    const start = rangeFmt.format(parseLocalDate(tournament.start));
+    if (!tournament.end || tournament.end === tournament.start) return start;
+    return `${start} – ${rangeFmt.format(parseLocalDate(tournament.end))}`;
+  }
+
+  return (
+    <div className="rounded-lg border border-gray-200 dark:border-gray-700">
+      {/* Day headers */}
+      <div className="grid grid-cols-7 rounded-t-lg border-b border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-800/50">
+        {row.cells.map((cell, i) => (
+          <div
+            key={cell.dayNumber}
+            className={`px-1 py-2 text-center ${i === 6 ? '' : 'border-r border-gray-200 dark:border-gray-700'}`}
+          >
+            <div className="text-[10px] font-medium uppercase tracking-wide text-gray-500 sm:text-xs dark:text-gray-400">
+              {weekdayLabels[i]}
+            </div>
+            <span
+              className={`mt-0.5 inline-flex h-6 min-w-6 items-center justify-center rounded-full px-1 text-xs sm:text-sm ${
+                cell.isToday
+                  ? 'bg-blue-600 font-semibold text-white dark:bg-blue-500'
+                  : 'text-gray-700 dark:text-gray-300'
+              }`}
+            >
+              {cell.date.getDate()}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {/* All-day band */}
+      <div className="relative">
+        {/* Column separators (+ today highlight) */}
+        <div className="pointer-events-none absolute inset-0 grid grid-cols-7">
+          {row.cells.map((cell, colIndex) => (
+            <div
+              key={cell.dayNumber}
+              className={`${colIndex === 6 ? '' : 'border-r border-gray-200 dark:border-gray-700'} ${
+                cell.isToday ? 'bg-blue-50/40 dark:bg-blue-900/10' : ''
+              }`}
+            />
+          ))}
+        </div>
+
+        {/* Event cards — grid columns = days, grid rows = lanes (auto-height) */}
+        <div
+          className="relative grid grid-cols-7 gap-1 p-1"
+          style={{ minHeight: minBand, gridAutoRows: 'min-content' }}
+        >
+          {row.segments.map((segment) => {
+            const { tournament, colOffset, colSpan, continuesLeft, continuesRight } = segment;
+            const meta = [tournament.city, typeLabel(tournament.type)].filter(Boolean).join(' · ');
+            const isOpen = open?.tournamentId === tournament.id && open?.colOffset === colOffset;
+            const popoverDate =
+              row.cells.find((c) => c.dayNumber === rowStart + colOffset)?.date ?? row.cells[0].date;
+
+            return (
+              <div
+                key={`${tournament.id}-${colOffset}`}
+                onClick={() => setOpen({ tournamentId: tournament.id, colOffset })}
+                title={tournament.name}
+                style={{
+                  gridColumn: `${colOffset + 1} / span ${colSpan}`,
+                  gridRow: segment.laneIndex + 1,
+                  zIndex: isOpen ? 20 : undefined,
+                }}
+                className={`relative cursor-pointer self-start rounded-md border px-1.5 py-1 transition-opacity hover:opacity-90 ${getTypeBarClasses(
+                  tournament.type,
+                )}`}
+              >
+                <span className="flex items-start gap-0.5 text-[11px] font-semibold leading-tight sm:text-xs">
+                  {continuesLeft && <span aria-hidden className="shrink-0">◀</span>}
+                  {isMobile ? (
+                    <span className="truncate">{tournament.name}</span>
+                  ) : (
+                    <Link
+                      href={`/results/${tournament.id}`}
+                      color="blue"
+                      underline="always"
+                      onClick={(e) => e.stopPropagation()}
+                      className="line-clamp-2"
+                    >
+                      {tournament.name}
+                    </Link>
+                  )}
+                  {continuesRight && <span aria-hidden className="ml-auto shrink-0">▶</span>}
+                </span>
+                {!isMobile && meta && (
+                  <span className="mt-0.5 block truncate text-[10px] leading-tight opacity-80">{meta}</span>
+                )}
+                {!isMobile && (
+                  <span className="block truncate text-[10px] leading-tight opacity-75">
+                    {getOrganizerName(tournament.orgType, tournament.orgNumber)}
+                  </span>
+                )}
+                {!isMobile && (
+                  <span className="block truncate text-[10px] leading-tight opacity-70">{formatRange(tournament)}</span>
+                )}
+
+                {isOpen && (
+                  <DayEventsPopover
+                    date={popoverDate}
+                    events={[tournament]}
+                    language={language}
+                    onClose={() => setOpen(null)}
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/calendar/calendarColors.ts
+++ b/src/components/calendar/calendarColors.ts
@@ -1,0 +1,46 @@
+/**
+ * Static Tailwind class maps for calendar event styling, keyed by tournament
+ * type. Every value is a full literal string so the Tailwind JIT scanner picks
+ * them up — never build these class names dynamically (see project memory).
+ *
+ * Type values match `TournamentType` (see tournamentFilters.ts:141-150):
+ *   2 Allsvenskan · 3 Individual · 4 SM-Trean · 5 Skol-SM
+ *   6 Svenska Cupen · 7 Grand Prix · 8 Yes2Chess · 9 Schackfyran
+ */
+
+/** Bar background + text + border, light and dark, per tournament type. */
+const TYPE_BAR_CLASSES: Record<number, string> = {
+  2: 'bg-blue-100 text-blue-800 border-blue-400 dark:bg-blue-900/40 dark:text-blue-200 dark:border-blue-500/60',
+  3: 'bg-emerald-100 text-emerald-800 border-emerald-400 dark:bg-emerald-900/40 dark:text-emerald-200 dark:border-emerald-500/60',
+  4: 'bg-violet-100 text-violet-800 border-violet-400 dark:bg-violet-900/40 dark:text-violet-200 dark:border-violet-500/60',
+  5: 'bg-amber-100 text-amber-800 border-amber-400 dark:bg-amber-900/40 dark:text-amber-200 dark:border-amber-500/60',
+  6: 'bg-rose-100 text-rose-800 border-rose-400 dark:bg-rose-900/40 dark:text-rose-200 dark:border-rose-500/60',
+  7: 'bg-cyan-100 text-cyan-800 border-cyan-400 dark:bg-cyan-900/40 dark:text-cyan-200 dark:border-cyan-500/60',
+  8: 'bg-fuchsia-100 text-fuchsia-800 border-fuchsia-400 dark:bg-fuchsia-900/40 dark:text-fuchsia-200 dark:border-fuchsia-500/60',
+  9: 'bg-teal-100 text-teal-800 border-teal-400 dark:bg-teal-900/40 dark:text-teal-200 dark:border-teal-500/60',
+};
+
+const DEFAULT_BAR =
+  'bg-gray-100 text-gray-800 border-gray-400 dark:bg-gray-700 dark:text-gray-200 dark:border-gray-500/60';
+
+/** Small solid swatch (for popover dots), per tournament type. */
+const TYPE_SWATCH_CLASSES: Record<number, string> = {
+  2: 'bg-blue-500',
+  3: 'bg-emerald-500',
+  4: 'bg-violet-500',
+  5: 'bg-amber-500',
+  6: 'bg-rose-500',
+  7: 'bg-cyan-500',
+  8: 'bg-fuchsia-500',
+  9: 'bg-teal-500',
+};
+
+const DEFAULT_SWATCH = 'bg-gray-400';
+
+export function getTypeBarClasses(type: number): string {
+  return TYPE_BAR_CLASSES[type] ?? DEFAULT_BAR;
+}
+
+export function getTypeSwatchClasses(type: number): string {
+  return TYPE_SWATCH_CLASSES[type] ?? DEFAULT_SWATCH;
+}

--- a/src/components/calendar/calendarPrefs.ts
+++ b/src/components/calendar/calendarPrefs.ts
@@ -1,0 +1,65 @@
+/**
+ * Small localStorage-backed preferences for the calendar page: which top tab
+ * (list/calendar) was last active, which calendar view (week/month), and the
+ * anchor date last viewed. All reads/writes guard against SSR and storage
+ * being unavailable.
+ */
+import { parseLocalDate } from '@/lib/api';
+
+const TAB_KEY = 'calendar-active-tab';
+const VIEW_KEY = 'calendar-view-mode';
+const ANCHOR_KEY = 'calendar-anchor';
+
+export type CalendarTab = 'calendar' | 'list';
+export type CalendarViewMode = 'week' | 'month';
+
+function read(key: string): string | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function write(key: string, value: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    /* storage unavailable — ignore */
+  }
+}
+
+export function getSavedTab(): CalendarTab | null {
+  const v = read(TAB_KEY);
+  return v === 'calendar' || v === 'list' ? v : null;
+}
+
+export function setSavedTab(tab: CalendarTab): void {
+  write(TAB_KEY, tab);
+}
+
+export function getSavedView(): CalendarViewMode | null {
+  const v = read(VIEW_KEY);
+  return v === 'week' || v === 'month' ? v : null;
+}
+
+export function setSavedView(view: CalendarViewMode): void {
+  write(VIEW_KEY, view);
+}
+
+/** Stored as a YYYY-MM-DD local date key. */
+export function getSavedAnchor(): Date | null {
+  const v = read(ANCHOR_KEY);
+  if (!v || !/^\d{4}-\d{2}-\d{2}$/.test(v)) return null;
+  const date = parseLocalDate(v);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function setSavedAnchor(date: Date): void {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  write(ANCHOR_KEY, `${y}-${m}-${d}`);
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export { useResponsiveDataPoints, type ResponsiveDataPointsOptions } from './useResponsiveDataPoints';
 export { useLiveUpdates, type LiveUpdatesState, type UseLiveUpdatesOptions } from './useLiveUpdates';
+export { useIsMobile } from './useIsMobile';

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+/**
+ * Returns true when the viewport is below `breakpoint` (default 640px — the
+ * Tailwind `sm` breakpoint). Defaults to false on the server / first render to
+ * avoid hydration mismatches, then corrects on mount and on resize.
+ */
+export function useIsMobile(breakpoint = 640): boolean {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const update = () => setIsMobile(window.innerWidth < breakpoint);
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, [breakpoint]);
+
+  return isMobile;
+}

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -177,6 +177,31 @@ export interface Translations {
         loading: string;
         noTournaments: string;
       };
+      tabs: {
+        list: string;
+        calendar: string;
+      };
+      views: {
+        week: string;
+        month: string;
+      };
+      nav: {
+        today: string;
+        prev: string;
+        next: string;
+        earliest: string;
+        latest: string;
+      };
+      moreEvents: string;
+      longerEvent: string;
+      continues: string;
+      dayDetails: {
+        organizer: string;
+        city: string;
+        type: string;
+        dateRange: string;
+        viewResults: string;
+      };
     };
     results: {
       title: string;
@@ -731,6 +756,31 @@ const translations: Record<Language, Translations> = {
           lastUpdated: 'Updated',
           loading: 'Loading tournaments...',
           noTournaments: 'No upcoming tournaments found',
+        },
+        tabs: {
+          list: 'List',
+          calendar: 'Calendar',
+        },
+        views: {
+          week: 'Week',
+          month: 'Month',
+        },
+        nav: {
+          today: 'Today',
+          prev: 'Previous',
+          next: 'Next',
+          earliest: 'First event',
+          latest: 'Last event',
+        },
+        moreEvents: '+{count} more',
+        longerEvent: 'Longer event',
+        continues: 'continues',
+        dayDetails: {
+          organizer: 'Organizer',
+          city: 'City',
+          type: 'Type',
+          dateRange: 'Dates',
+          viewResults: 'View results',
         },
       },
       results: {
@@ -1292,6 +1342,31 @@ const translations: Record<Language, Translations> = {
           lastUpdated: 'Uppdaterad',
           loading: 'Laddar turneringar...',
           noTournaments: 'Inga kommande turneringar hittades',
+        },
+        tabs: {
+          list: 'Lista',
+          calendar: 'Kalender',
+        },
+        views: {
+          week: 'Vecka',
+          month: 'Månad',
+        },
+        nav: {
+          today: 'Idag',
+          prev: 'Föregående',
+          next: 'Nästa',
+          earliest: 'Första evenemanget',
+          latest: 'Sista evenemanget',
+        },
+        moreEvents: '+{count} fler',
+        longerEvent: 'Längre evenemang',
+        continues: 'fortsätter',
+        dayDetails: {
+          organizer: 'Arrangör',
+          city: 'Ort',
+          type: 'Typ',
+          dateRange: 'Datum',
+          viewResults: 'Visa resultat',
         },
       },
       results: {

--- a/src/lib/utils/__tests__/calendarLayout.test.ts
+++ b/src/lib/utils/__tests__/calendarLayout.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from 'vitest';
+import { TournamentType, TournamentState } from '@msvens/schack-se-sdk';
+import type { TournamentDto } from '@msvens/schack-se-sdk';
+import {
+  toDayNumber,
+  parseEventDays,
+  buildMonthMatrix,
+  buildWeekCells,
+  packRow,
+  buildWeekRow,
+  tournamentsForDay,
+  getEventDateBounds,
+  LONG_EVENT_THRESHOLD,
+} from '@/lib/utils/calendarLayout';
+
+/** Minimal mock — only the fields the layout functions inspect. */
+function makeTournament(overrides: Partial<TournamentDto>): TournamentDto {
+  return {
+    id: 1,
+    name: 'Test',
+    start: '2024-01-01',
+    end: '2024-01-01',
+    city: '',
+    arena: '',
+    type: TournamentType.INDIVIDUAL,
+    state: TournamentState.FINISHED,
+    ia: 0,
+    secjudges: '',
+    thinkingTime: '',
+    allowForeignPlayers: 0,
+    teamtournamentPlayerListType: 0,
+    ageFilter: 0,
+    nrOfPartLink: '',
+    orgType: 0,
+    orgNumber: 0,
+    ratingRegDate: '',
+    ratingRegDate2: '',
+    fideregged: 0,
+    online: 0,
+    y2cRules: 0,
+    teamNrOfDaysRegged: 0,
+    showPublic: 1,
+    invitationurl: '',
+    secParsedJudges: [],
+    rootClasses: [],
+    ...overrides,
+  } as TournamentDto;
+}
+
+// Anchor inside a known week. 2024-06-12 is a Wednesday;
+// its Mon–Sun week is 2024-06-10 .. 2024-06-16.
+const WEEK_ANCHOR = new Date(2024, 5, 12);
+
+describe('parseEventDays', () => {
+  it('returns null when start is missing', () => {
+    expect(parseEventDays(makeTournament({ start: '' }))).toBeNull();
+  });
+
+  it('treats empty end as single day', () => {
+    const ev = parseEventDays(makeTournament({ start: '2024-06-10', end: '' }));
+    expect(ev).not.toBeNull();
+    expect(ev!.start).toBe(ev!.end);
+  });
+
+  it('clamps end before start', () => {
+    const ev = parseEventDays(makeTournament({ start: '2024-06-10', end: '2024-06-08' }))!;
+    expect(ev.end).toBe(ev.start);
+  });
+
+  it('computes inclusive span', () => {
+    const ev = parseEventDays(makeTournament({ start: '2024-06-10', end: '2024-06-12' }))!;
+    expect(ev.end - ev.start + 1).toBe(3);
+  });
+});
+
+describe('buildMonthMatrix / buildWeekCells', () => {
+  it('builds a Monday-first 6x7 grid', () => {
+    const matrix = buildMonthMatrix(WEEK_ANCHOR, toDayNumber(WEEK_ANCHOR));
+    expect(matrix).toHaveLength(6);
+    expect(matrix.every((r) => r.length === 7)).toBe(true);
+    // June 2024 starts on a Saturday → first cell is Mon 2024-05-27.
+    expect(matrix[0][0].date.getDate()).toBe(27);
+    expect(matrix[0][0].inCurrentMonth).toBe(false);
+  });
+
+  it('builds a Mon–Sun week', () => {
+    const cells = buildWeekCells(WEEK_ANCHOR, toDayNumber(WEEK_ANCHOR));
+    expect(cells).toHaveLength(7);
+    expect(cells[0].date.getDate()).toBe(10); // Monday
+    expect(cells[6].date.getDate()).toBe(16); // Sunday
+  });
+
+  it('flags today', () => {
+    const today = toDayNumber(WEEK_ANCHOR);
+    const cells = buildWeekCells(WEEK_ANCHOR, today);
+    expect(cells.filter((c) => c.isToday)).toHaveLength(1);
+    expect(cells.find((c) => c.isToday)!.date.getDate()).toBe(12);
+  });
+});
+
+describe('packRow — single week row 2024-06-10..16', () => {
+  const cells = buildWeekCells(WEEK_ANCHOR, toDayNumber(WEEK_ANCHOR));
+
+  it('positions a single-day event in the right column', () => {
+    const row = packRow(cells, [makeTournament({ start: '2024-06-12', end: '2024-06-12' })]);
+    expect(row.segments).toHaveLength(1);
+    expect(row.segments[0]).toMatchObject({ colOffset: 2, colSpan: 1, continuesLeft: false, continuesRight: false });
+  });
+
+  it('spans a multi-day event within the week', () => {
+    const row = packRow(cells, [makeTournament({ start: '2024-06-11', end: '2024-06-13' })]);
+    expect(row.segments[0]).toMatchObject({ colOffset: 1, colSpan: 3, continuesLeft: false, continuesRight: false });
+  });
+
+  it('clips an event that started before this row and flags continuesLeft', () => {
+    const row = packRow(cells, [makeTournament({ start: '2024-06-08', end: '2024-06-11' })]);
+    expect(row.segments[0]).toMatchObject({ colOffset: 0, colSpan: 2, continuesLeft: true, continuesRight: false });
+  });
+
+  it('clips an event that runs past this row and flags continuesRight', () => {
+    // 5-day event Sat 15 → Wed 19: in this row only 15,16 are visible (cols 5,6).
+    const row = packRow(cells, [makeTournament({ start: '2024-06-15', end: '2024-06-19' })]);
+    expect(row.segments[0]).toMatchObject({ colOffset: 5, colSpan: 2, continuesLeft: false, continuesRight: true });
+  });
+
+  it('renders a >7-day event as a start-only marker', () => {
+    const row = packRow(cells, [makeTournament({ start: '2024-06-11', end: '2024-06-30' })]);
+    expect(row.segments).toHaveLength(1);
+    expect(row.segments[0]).toMatchObject({ startOnly: true, colOffset: 1, colSpan: 1 });
+  });
+
+  it('does not show a long event on a non-start row', () => {
+    // Long event whose start is in a previous week → nothing in this row.
+    const row = packRow(cells, [makeTournament({ start: '2024-06-01', end: '2024-06-30' })]);
+    expect(row.segments).toHaveLength(0);
+  });
+
+  it('lane-packs overlapping events onto separate lanes', () => {
+    const row = packRow(cells, [
+      makeTournament({ id: 1, start: '2024-06-10', end: '2024-06-12' }),
+      makeTournament({ id: 2, start: '2024-06-11', end: '2024-06-13' }),
+      makeTournament({ id: 3, start: '2024-06-15', end: '2024-06-16' }),
+    ]);
+    const lane = (id: number) => row.segments.find((s) => s.tournament.id === id)!.laneIndex;
+    expect(lane(1)).toBe(0);
+    expect(lane(2)).toBe(1); // overlaps #1 → new lane
+    expect(lane(3)).toBe(0); // no overlap with #1 → reuses lane 0
+    expect(row.maxLanes).toBe(2);
+  });
+});
+
+describe('week-boundary split (the critical case)', () => {
+  it('splits a 4-day event straddling Sun→Mon into two segments', () => {
+    // Fri 2024-06-14 → Mon 2024-06-17. Week A: 10..16, Week B: 17..23.
+    const t = makeTournament({ start: '2024-06-14', end: '2024-06-17' });
+    const today = toDayNumber(WEEK_ANCHOR);
+
+    const rowA = packRow(buildWeekCells(new Date(2024, 5, 12), today), [t]);
+    const rowB = packRow(buildWeekCells(new Date(2024, 5, 19), today), [t]);
+
+    // Week A: Fri,Sat,Sun = cols 4,5,6, continues into next week.
+    expect(rowA.segments[0]).toMatchObject({ colOffset: 4, colSpan: 3, continuesLeft: false, continuesRight: true });
+    // Week B: Mon = col 0, continued from previous week.
+    expect(rowB.segments[0]).toMatchObject({ colOffset: 0, colSpan: 1, continuesLeft: true, continuesRight: false });
+  });
+});
+
+describe('tournamentsForDay', () => {
+  const events = [
+    makeTournament({ id: 1, start: '2024-06-11', end: '2024-06-13' }), // short, covers 12
+    makeTournament({ id: 2, start: '2024-06-12', end: '2024-06-12' }), // single on 12
+    makeTournament({ id: 3, start: '2024-06-01', end: '2024-06-30' }), // long, starts before 12
+  ];
+
+  it('includes short events covering the day', () => {
+    const ids = tournamentsForDay(events, toDayNumber(new Date(2024, 5, 12))).map((t) => t.id);
+    expect(ids).toContain(1);
+    expect(ids).toContain(2);
+  });
+
+  it('excludes long events on a non-start day', () => {
+    const ids = tournamentsForDay(events, toDayNumber(new Date(2024, 5, 12))).map((t) => t.id);
+    expect(ids).not.toContain(3);
+  });
+
+  it('includes a long event on its start day', () => {
+    const ids = tournamentsForDay(events, toDayNumber(new Date(2024, 5, 1))).map((t) => t.id);
+    expect(ids).toContain(3);
+  });
+});
+
+describe('getEventDateBounds', () => {
+  it('returns null for an empty set', () => {
+    expect(getEventDateBounds([])).toBeNull();
+  });
+
+  it('returns earliest and latest start dates', () => {
+    const bounds = getEventDateBounds([
+      makeTournament({ start: '2024-06-20' }),
+      makeTournament({ start: '2024-06-05' }),
+      makeTournament({ start: '2024-06-12' }),
+    ])!;
+    expect(bounds.earliest.getDate()).toBe(5);
+    expect(bounds.latest.getDate()).toBe(20);
+  });
+});
+
+describe('constants', () => {
+  it('uses a 7-day long-event threshold', () => {
+    expect(LONG_EVENT_THRESHOLD).toBe(7);
+  });
+});

--- a/src/lib/utils/calendarLayout.ts
+++ b/src/lib/utils/calendarLayout.ts
@@ -1,0 +1,260 @@
+/**
+ * Pure date-math + event layout helpers for the calendar week/month views.
+ *
+ * No React, no i18n — just data transformation so it stays easy to reason about
+ * and test. All date parsing goes through `parseLocalDate` (local midnight) and
+ * all span math is done on integer "day numbers" to avoid DST/UTC off-by-one
+ * bugs (see the project memory note on `value && ...` and date pitfalls).
+ */
+import { parseLocalDate, type TournamentDto } from '@/lib/api';
+
+/** Events longer than this many days are marked on their start date only. */
+export const LONG_EVENT_THRESHOLD = 7;
+
+/** Max lanes (stacked bars) rendered per day cell in month view before "+N more". */
+export const MONTH_MAX_LANES = 3;
+
+export interface DayCell {
+  /** Local-midnight Date for this day. */
+  date: Date;
+  /** Stable integer day number (UTC-epoch based, DST-safe). */
+  dayNumber: number;
+  /** True when this cell belongs to the anchor month (false for padded days). */
+  inCurrentMonth: boolean;
+  /** True when this cell is today. */
+  isToday: boolean;
+}
+
+export interface PositionedSegment {
+  tournament: TournamentDto;
+  /** 0-based column within the row (0 = first day of the row). */
+  colOffset: number;
+  /** Number of columns the bar spans within this row. */
+  colSpan: number;
+  /** Vertical lane (0-based) for stacking overlapping bars. */
+  laneIndex: number;
+  /** Bar continues into the previous row (render a ◀ hint). */
+  continuesLeft: boolean;
+  /** Bar continues into the next row (render a ▶ hint). */
+  continuesRight: boolean;
+  /** True for >7-day events: a single start-date marker rather than a span. */
+  startOnly: boolean;
+}
+
+export interface PackedRow {
+  /** The 7 day cells of this row (Mon–Sun). */
+  cells: DayCell[];
+  /** Positioned + lane-packed segments visible in this row. */
+  segments: PositionedSegment[];
+  /** Number of lanes used — drives the row's min-height. */
+  maxLanes: number;
+}
+
+/**
+ * Convert a Date to a stable integer day number based on its calendar
+ * Y/M/D (timezone/DST independent). Two dates with the same calendar day
+ * always produce the same number.
+ */
+export function toDayNumber(date: Date): number {
+  return Math.floor(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()) / 86_400_000);
+}
+
+/** Add `n` days to a date (DST-safe — uses calendar arithmetic). */
+export function addDays(date: Date, n: number): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate() + n);
+}
+
+/** Add `n` months to a date, anchored to the 1st. */
+export function addMonths(date: Date, n: number): Date {
+  return new Date(date.getFullYear(), date.getMonth() + n, 1);
+}
+
+/** Monday-based day-of-week index: Mon=0 … Sun=6. */
+function mondayIndex(date: Date): number {
+  return (date.getDay() + 6) % 7;
+}
+
+/**
+ * Parse a tournament's start/end into inclusive day numbers.
+ * Returns null when there's no usable start date. Guards empty `end`
+ * (single-day) and clamps a malformed `end < start`.
+ */
+export function parseEventDays(t: TournamentDto): { start: number; end: number } | null {
+  if (!t.start) return null;
+  const start = toDayNumber(parseLocalDate(t.start));
+  let end = start;
+  if (t.end) {
+    end = toDayNumber(parseLocalDate(t.end));
+    if (end < start) end = start;
+  }
+  return { start, end };
+}
+
+function makeCell(date: Date, anchorMonth: number, todayDayNumber: number): DayCell {
+  const dayNumber = toDayNumber(date);
+  return {
+    date,
+    dayNumber,
+    inCurrentMonth: date.getMonth() === anchorMonth,
+    isToday: dayNumber === todayDayNumber,
+  };
+}
+
+/**
+ * Build a Monday-first 6×7 month matrix for the month containing `anchor`,
+ * padded with adjacent-month days.
+ */
+export function buildMonthMatrix(anchor: Date, todayDayNumber: number): DayCell[][] {
+  const year = anchor.getFullYear();
+  const month = anchor.getMonth();
+  const offset = mondayIndex(new Date(year, month, 1));
+
+  const rows: DayCell[][] = [];
+  for (let row = 0; row < 6; row++) {
+    const cells: DayCell[] = [];
+    for (let col = 0; col < 7; col++) {
+      const dayOfMonth = 1 - offset + row * 7 + col;
+      cells.push(makeCell(new Date(year, month, dayOfMonth), month, todayDayNumber));
+    }
+    rows.push(cells);
+  }
+  return rows;
+}
+
+/** Build the 7 Mon–Sun cells of the week containing `anchor`. */
+export function buildWeekCells(anchor: Date, todayDayNumber: number): DayCell[] {
+  const offset = mondayIndex(anchor);
+  const cells: DayCell[] = [];
+  for (let i = 0; i < 7; i++) {
+    const date = addDays(anchor, -offset + i);
+    cells.push(makeCell(date, date.getMonth(), todayDayNumber));
+  }
+  return cells;
+}
+
+/**
+ * Position + lane-pack a single contiguous row of day cells.
+ *
+ * Each tournament is split to the portion visible in this row; a >7-day event
+ * collapses to a single start-date marker. Overlapping segments are greedily
+ * assigned to lanes (left-to-right by start column) so they stack vertically.
+ */
+export function packRow(cells: DayCell[], tournaments: TournamentDto[]): PackedRow {
+  const rowStart = cells[0].dayNumber;
+  const rowEnd = cells[cells.length - 1].dayNumber;
+
+  const segments: PositionedSegment[] = [];
+  for (const tournament of tournaments) {
+    const ev = parseEventDays(tournament);
+    if (!ev) continue;
+
+    const startOnly = ev.end - ev.start + 1 > LONG_EVENT_THRESHOLD;
+    if (startOnly) {
+      // Only the start day gets a marker, and only if it falls in this row.
+      if (ev.start < rowStart || ev.start > rowEnd) continue;
+      segments.push({
+        tournament,
+        colOffset: ev.start - rowStart,
+        colSpan: 1,
+        laneIndex: 0,
+        continuesLeft: false,
+        continuesRight: false,
+        startOnly: true,
+      });
+    } else {
+      const segStart = Math.max(ev.start, rowStart);
+      const segEnd = Math.min(ev.end, rowEnd);
+      if (segStart > segEnd) continue;
+      segments.push({
+        tournament,
+        colOffset: segStart - rowStart,
+        colSpan: segEnd - segStart + 1,
+        laneIndex: 0,
+        continuesLeft: ev.start < rowStart,
+        continuesRight: ev.end > rowEnd,
+        startOnly: false,
+      });
+    }
+  }
+
+  // Greedy lane packing: sort by start column, longer spans first on ties.
+  segments.sort((a, b) => a.colOffset - b.colOffset || b.colSpan - a.colSpan);
+  const laneEndCol: number[] = []; // last occupied column per lane
+  for (const seg of segments) {
+    const endCol = seg.colOffset + seg.colSpan - 1;
+    let placed = false;
+    for (let lane = 0; lane < laneEndCol.length; lane++) {
+      if (laneEndCol[lane] < seg.colOffset) {
+        seg.laneIndex = lane;
+        laneEndCol[lane] = endCol;
+        placed = true;
+        break;
+      }
+    }
+    if (!placed) {
+      seg.laneIndex = laneEndCol.length;
+      laneEndCol.push(endCol);
+    }
+  }
+
+  return { cells, segments, maxLanes: laneEndCol.length };
+}
+
+/** Build all 6 packed rows for a month view. */
+export function buildMonthRows(
+  anchor: Date,
+  tournaments: TournamentDto[],
+  todayDayNumber: number,
+): PackedRow[] {
+  return buildMonthMatrix(anchor, todayDayNumber).map((cells) => packRow(cells, tournaments));
+}
+
+/** Build the single packed row for a week view. */
+export function buildWeekRow(
+  anchor: Date,
+  tournaments: TournamentDto[],
+  todayDayNumber: number,
+): PackedRow {
+  return packRow(buildWeekCells(anchor, todayDayNumber), tournaments);
+}
+
+/**
+ * Tournaments to surface for a given day in a popover. Matches what is *drawn*:
+ * short events covering the day, plus long events whose start is that day.
+ */
+export function tournamentsForDay(tournaments: TournamentDto[], dayNumber: number): TournamentDto[] {
+  return tournaments.filter((t) => {
+    const ev = parseEventDays(t);
+    if (!ev) return false;
+    if (ev.end - ev.start + 1 > LONG_EVENT_THRESHOLD) return ev.start === dayNumber;
+    return dayNumber >= ev.start && dayNumber <= ev.end;
+  });
+}
+
+/**
+ * Earliest and latest tournament *start* dates in the set, as local-midnight
+ * Dates. Used to bound navigation and to jump to first/last event.
+ */
+export function getEventDateBounds(tournaments: TournamentDto[]): { earliest: Date; latest: Date } | null {
+  let min: number | null = null;
+  let max: number | null = null;
+  let minDate: Date | null = null;
+  let maxDate: Date | null = null;
+
+  for (const t of tournaments) {
+    if (!t.start) continue;
+    const date = parseLocalDate(t.start);
+    const day = toDayNumber(date);
+    if (min === null || day < min) {
+      min = day;
+      minDate = date;
+    }
+    if (max === null || day > max) {
+      max = day;
+      maxDate = date;
+    }
+  }
+
+  if (!minDate || !maxDate) return null;
+  return { earliest: minDate, latest: maxDate };
+}


### PR DESCRIPTION
## What

Adds a custom **Week** and **Month** calendar view alongside the existing tournament list on `/calendar`, selectable via **Calendar / List** tabs (Calendar is now the default).

The schack.se data is date-only (no time-of-day) and tournaments are often multi-day/multi-week, so this is an all-day, multi-day **spanning-bar** calendar rather than an hourly scheduler — built custom to fully own light/dark theming, sv/en i18n, and the spanning layout.

## Highlights

- **Layout engine** (`calendarLayout.ts`, pure + unit-tested): Monday-first month grid, week ranges, per-week-row segment splitting, and greedy lane-packing. Events spanning **≤ 7 days** render as spanning bars (split correctly across week-row boundaries); longer events show as a start-date marker.
- **Month view**: compact bars, `+N more` overflow, and a detail popover that shows the **clicked event** (or the whole day from the cell / overflow) and **self-positions** to stay on screen.
- **Week view**: content-height event cards (CSS grid) showing name, city, type, organizer and date range; the **title links** to the tournament while the card opens detail. Compact title-only cards on mobile.
- **Filters** (district / category / type / state) feed all views from the same filtered set.
- **Persistence**: active tab, week/month mode, and anchor date saved to `localStorage`; responsive behaviour via a new `useIsMobile` hook.
- **Navigation**: prev/next, Today, and jump-to-first/last-event, bounded to the event date range.

## Testing

- `pnpm check` (typecheck, lint, 55 tests, build) passes.
- 21 new unit tests in `calendarLayout.test.ts` cover segment splitting (incl. the Sun→Mon week-boundary case), lane packing, the >7-day rule, and event bounds.

## Notes

- Reuses existing patterns/components: `parseLocalDate`, `getTournamentTypeKey`, `getOrganizerName`, `Link`, `PageLayout`, the inline tab pattern, and translation conventions.
- First iteration intended for tuning — bar density, popover placement, and colors are easy to adjust.