### PR TITLE
Derive tournament status from dates, not the unreliable state field

### DIFF
--- a/src/app/results/[tournamentId]/[groupId]/page.tsx
+++ b/src/app/results/[tournamentId]/[groupId]/page.tsx
@@ -3,7 +3,8 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { PageLayout } from '@/components/layout/PageLayout';
-import { TournamentService, getResultDisplayString, normalizeEloLookupDate, parseLocalDate, getOpponentKind, isTeamPairing, isLooseTeamTournament, TournamentDto, TournamentClassDto, TournamentClassGroupDto, TournamentEndResultDto, TournamentRoundResultDto, TournamentState, TeamTournamentEndResultDto } from '@/lib/api';
+import { TournamentService, getResultDisplayString, normalizeEloLookupDate, parseLocalDate, getOpponentKind, isTeamPairing, isLooseTeamTournament, TournamentDto, TournamentClassDto, TournamentClassGroupDto, TournamentEndResultDto, TournamentRoundResultDto, TeamTournamentEndResultDto } from '@/lib/api';
+import { getTournamentStatus } from '@/lib/utils/tournamentFilters';
 import { useLanguage } from '@/context/LanguageContext';
 import { getTranslation } from '@/lib/translations';
 import { useGroupResults, PlayerDateRequest } from '@/context/GroupResultsContext';
@@ -314,25 +315,22 @@ export default function GroupResultsPage() {
   // Determine tournament/group state for display
   // These are only used when resultsLoading is false (guarded in JSX)
   //
-  // hasRoundResults: If there are round results, games have been played regardless of API state
+  // hasRoundResults: round results existing proves games have been played,
+  // regardless of the (unreliable) API state.
   const hasRoundResults = isTeamTournament
     ? teamRoundResults.length > 0
     : individualRoundResults.length > 0;
 
-  // isNotStarted: Show registration view only if state is REGISTRATION AND no games played
-  const isNotStarted = !hasRoundResults && (
-    tournamentState === TournamentState.REGISTRATION
-    || (groupStartDate && tournamentState === null && new Date() < parseLocalDate(groupStartDate))
-  );
-
-  // isFinished: Today's date (local midnight) is strictly after the group end date
-  // Uses parseLocalDate to avoid UTC midnight issues with date-only strings
-  // TODO: Revisit whether tournamentState should also factor in here
-  const isFinished = groupEndDate && (() => {
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    return today > parseLocalDate(groupEndDate);
-  })();
+  // Derive status from the same shared helper the results/calendar lists use,
+  // fed this group's dates + the round-results signal (see tournamentFilters.ts).
+  const status = getTournamentStatus({
+    start: groupStartDate,
+    end: groupEndDate,
+    state: tournamentState,
+    hasRoundResults,
+  });
+  const isNotStarted = status === 'upcoming';
+  const isFinished = status === 'finished';
 
   // Special-format detection — see the tournament-formats reference notes.
   //

--- a/src/lib/utils/__tests__/tournamentFilters.test.ts
+++ b/src/lib/utils/__tests__/tournamentFilters.test.ts
@@ -7,6 +7,7 @@ import {
   filterByCategory,
   filterByType,
   filterByState,
+  getTournamentStatus,
   getAllTournamentTypes,
   getTournamentTypeKey,
 } from '@/lib/utils/tournamentFilters';
@@ -91,21 +92,70 @@ describe('countByType', () => {
 });
 
 // ---------------------------------------------------------------------------
-// countByState
+// getTournamentStatus  (date-first; state is only a weak hint)
+// ---------------------------------------------------------------------------
+describe('getTournamentStatus', () => {
+  const now = new Date('2025-06-15T12:00:00');
+
+  it('finished when past the end date', () => {
+    expect(getTournamentStatus({ start: '2025-06-01', end: '2025-06-10' }, now)).toBe('finished');
+  });
+
+  it('upcoming when before the start date', () => {
+    expect(getTournamentStatus({ start: '2025-07-01', end: '2025-07-02' }, now)).toBe('upcoming');
+  });
+
+  it('ongoing when inside the date window', () => {
+    expect(getTournamentStatus({ start: '2025-06-01', end: '2025-06-30' }, now)).toBe('ongoing');
+  });
+
+  it('THE BUG: stale state=registration on a past event is still finished', () => {
+    expect(
+      getTournamentStatus({ start: '2025-01-01', end: '2025-01-02', state: TournamentState.REGISTRATION }, now),
+    ).toBe('finished');
+  });
+
+  it('honours an explicit registration state inside the window (no results yet)', () => {
+    expect(
+      getTournamentStatus({ start: '2025-06-01', end: '2025-06-30', state: TournamentState.REGISTRATION }, now),
+    ).toBe('upcoming');
+  });
+
+  it('round results prove it started: ongoing while in window, finished once past end', () => {
+    expect(getTournamentStatus({ end: '2025-06-30', hasRoundResults: true }, now)).toBe('ongoing');
+    expect(getTournamentStatus({ end: '2025-06-01', hasRoundResults: true }, now)).toBe('finished');
+  });
+
+  it('treats the last day (today === end) as ongoing, not finished', () => {
+    expect(getTournamentStatus({ start: '2025-06-01', end: '2025-06-15' }, now)).toBe('ongoing');
+  });
+
+  it('falls back to raw state when no dates are present', () => {
+    expect(getTournamentStatus({ state: TournamentState.STARTED }, now)).toBe('ongoing');
+    expect(getTournamentStatus({ state: TournamentState.FINISHED }, now)).toBe('finished');
+  });
+
+  it('unknown when neither dates nor a usable state are available (e.g. text-search stub)', () => {
+    expect(getTournamentStatus({ start: '', end: '', state: 0 }, now)).toBe('unknown');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// countByState  (now derives status from dates: registration=upcoming, started=ongoing)
 // ---------------------------------------------------------------------------
 describe('countByState', () => {
-  it('counts all three states', () => {
+  it('buckets by derived status, ignoring the stale state field', () => {
     const tournaments = [
-      makeTournament({ state: TournamentState.REGISTRATION }),
-      makeTournament({ state: TournamentState.STARTED }),
-      makeTournament({ state: TournamentState.STARTED }),
-      makeTournament({ state: TournamentState.FINISHED }),
+      makeTournament({ start: '2099-01-01', end: '2099-01-02', state: TournamentState.REGISTRATION }), // upcoming
+      makeTournament({ start: '2000-01-01', end: '2099-01-02', state: TournamentState.STARTED }), // ongoing
+      makeTournament({ start: '2000-01-01', end: '2000-01-02', state: TournamentState.REGISTRATION }), // stale → finished
+      makeTournament({ start: '2000-01-01', end: '2000-01-02', state: TournamentState.FINISHED }), // finished
     ];
     expect(countByState(tournaments)).toEqual({
       all: 4,
       registration: 1,
-      started: 2,
-      finished: 1,
+      started: 1,
+      finished: 2,
     });
   });
 });
@@ -160,18 +210,22 @@ describe('filterByType', () => {
 // ---------------------------------------------------------------------------
 describe('filterByState', () => {
   const tournaments = [
-    makeTournament({ id: 1, state: TournamentState.REGISTRATION }),
-    makeTournament({ id: 2, state: TournamentState.FINISHED }),
+    makeTournament({ id: 1, start: '2000-01-01', end: '2000-01-02', state: TournamentState.REGISTRATION }), // stale → finished
+    makeTournament({ id: 2, start: '2000-01-01', end: '2099-01-02', state: TournamentState.STARTED }), // ongoing
+    makeTournament({ id: 3, start: '2099-01-01', end: '2099-01-02', state: TournamentState.REGISTRATION }), // upcoming
   ];
 
   it('null returns all', () => {
-    expect(filterByState(tournaments, null)).toHaveLength(2);
+    expect(filterByState(tournaments, null)).toHaveLength(3);
   });
 
-  it('specific state filters correctly', () => {
-    const result = filterByState(tournaments, TournamentState.FINISHED);
-    expect(result).toHaveLength(1);
-    expect(result[0].id).toBe(2);
+  it('FINISHED matches date-finished events, including a stale registration state', () => {
+    expect(filterByState(tournaments, TournamentState.FINISHED).map(t => t.id)).toEqual([1]);
+  });
+
+  it('STARTED matches ongoing, REGISTRATION matches upcoming', () => {
+    expect(filterByState(tournaments, TournamentState.STARTED).map(t => t.id)).toEqual([2]);
+    expect(filterByState(tournaments, TournamentState.REGISTRATION).map(t => t.id)).toEqual([3]);
   });
 });
 

--- a/src/lib/utils/tournamentFilters.ts
+++ b/src/lib/utils/tournamentFilters.ts
@@ -1,8 +1,14 @@
 /**
- * Utility functions for filtering tournaments by category, type, and state
+ * Utility functions for filtering tournaments by category, type, and status.
+ *
+ * Status note: the API `state` field is unreliable — organizers routinely never
+ * flip it from "registration" once an event has happened, so old finished
+ * tournaments still report state=1. We therefore derive status from DATES
+ * (`getTournamentStatus`) and treat `state` only as a weak hint. The detail
+ * view uses the same helper, so list and detail agree.
  */
 
-import { TournamentDto, TournamentType, TournamentState, isTeamTournament } from '@/lib/api';
+import { TournamentDto, TournamentType, TournamentState, isTeamTournament, parseLocalDate } from '@/lib/api';
 
 // =============================================================================
 // Types
@@ -24,6 +30,58 @@ export interface StateCounts {
 }
 
 export type TypeCounts = Record<number | 'all', number>;
+
+/** Derived tournament status (from dates, not the unreliable API `state`). */
+export type TournamentStatus = 'upcoming' | 'ongoing' | 'finished' | 'unknown';
+
+export interface TournamentStatusInput {
+  /** YYYY-MM-DD start date (tournament- or group-level). */
+  start?: string | null;
+  /** YYYY-MM-DD end date (tournament- or group-level). */
+  end?: string | null;
+  /** Raw API state — used only as a weak hint when dates can't decide. */
+  state?: number | null;
+  /** True if any round results exist — proves the event has started. */
+  hasRoundResults?: boolean;
+}
+
+/**
+ * Derive a tournament's status, trusting DATES over the API `state` field.
+ *
+ * Order matters: a past end date wins over `state` (that's what fixes the
+ * stale-"registration" bug). Round results, when known, prove the event has
+ * started. `state` is consulted only inside the date window or when no dates
+ * are available at all (e.g. text-search stubs → `unknown`).
+ */
+export function getTournamentStatus(t: TournamentStatusInput, now: Date = new Date()): TournamentStatus {
+  const today = new Date(now);
+  today.setHours(0, 0, 0, 0);
+  const todayMs = today.getTime();
+
+  const toMs = (d?: string | null): number | null => {
+    if (!d) return null;
+    const parsed = parseLocalDate(d).getTime();
+    return Number.isNaN(parsed) ? null : parsed;
+  };
+  const startMs = toMs(t.start);
+  const endMs = toMs(t.end);
+
+  // Results exist → it has started; finished only once past the end date.
+  if (t.hasRoundResults) {
+    return endMs !== null && todayMs > endMs ? 'finished' : 'ongoing';
+  }
+  // Past the end date → finished, regardless of the (unreliable) state field.
+  if (endMs !== null && todayMs > endMs) return 'finished';
+  // Before the start date → upcoming.
+  if (startMs !== null && todayMs < startMs) return 'upcoming';
+  // Inside the date window: honour an explicit registration state if present.
+  if (t.state === TournamentState.REGISTRATION) return 'upcoming';
+  if (startMs !== null || endMs !== null) return 'ongoing';
+  // No dates at all: fall back to the raw state, else unknown.
+  if (t.state === TournamentState.STARTED) return 'ongoing';
+  if (t.state === TournamentState.FINISHED) return 'finished';
+  return 'unknown';
+}
 
 // =============================================================================
 // Count Functions
@@ -61,18 +119,21 @@ export function countByType(tournaments: TournamentDto[]): TypeCounts {
 }
 
 /**
- * Count tournaments by state
+ * Count tournaments by derived status. The bucket names are kept for the
+ * existing filter UI: registration = upcoming, started = ongoing, finished =
+ * finished. (`unknown` contributes only to `all`.)
  */
 export function countByState(tournaments: TournamentDto[]): StateCounts {
   const counts: StateCounts = { all: 0, registration: 0, started: 0, finished: 0 };
 
   tournaments.forEach(t => {
     counts.all++;
-    if (t.state === TournamentState.REGISTRATION) {
+    const status = getTournamentStatus(t);
+    if (status === 'upcoming') {
       counts.registration++;
-    } else if (t.state === TournamentState.STARTED) {
+    } else if (status === 'ongoing') {
       counts.started++;
-    } else if (t.state === TournamentState.FINISHED) {
+    } else if (status === 'finished') {
       counts.finished++;
     }
   });
@@ -117,8 +178,10 @@ export function filterByType(
 }
 
 /**
- * Filter tournaments by state
- * @param state - Tournament state number, or null for all states
+ * Filter tournaments by derived status. The `state` argument keeps the existing
+ * filter-UI contract (the TournamentState enum values), but matching is done on
+ * the date-derived status: REGISTRATION→upcoming, STARTED→ongoing,
+ * FINISHED→finished. `null` returns everything.
  */
 export function filterByState(
   tournaments: TournamentDto[],
@@ -128,7 +191,16 @@ export function filterByState(
     return tournaments;
   }
 
-  return tournaments.filter(t => t.state === state);
+  const target: TournamentStatus =
+    state === TournamentState.REGISTRATION
+      ? 'upcoming'
+      : state === TournamentState.STARTED
+        ? 'ongoing'
+        : state === TournamentState.FINISHED
+          ? 'finished'
+          : 'unknown';
+
+  return tournaments.filter(t => getTournamentStatus(t) === target);
 }
 
 // =============================================================================


### PR DESCRIPTION
## Problem
The results/calendar lists filter and label tournaments by the API `state` field — but organizers rarely flip it off "registration" once an event has happened. So long-finished events showed as "in registration", and the count grew the further back the search window went (more stale records). The detail view already worked around this (it derives from group dates + round results), so the two disagreed.

## Fix
- **Shared `getTournamentStatus({ start, end, state?, hasRoundResults? })`** in `tournamentFilters.ts` → `'upcoming' | 'ongoing' | 'finished' | 'unknown'`. Derives from **dates first**; the key ordering is *a past end date wins over `state`* (that's what fixes the stale label). `hasRoundResults` proves the event started; `state` is only a weak hint inside the date window or when no dates exist.
- **`countByState` / `filterByState` now derive through it** — public API and the filter UI/translations are unchanged (minimal blast radius). The "Registration/Started/Finished" labels now map to upcoming/ongoing/finished.
- **Detail view unified** onto the same helper (removed the duplicate inline logic + the old TODO). One status definition everywhere.
- **+10 unit tests**, including an explicit test for the stale-`state=registration`-on-a-past-event case.

## Behavior note
An abandoned tournament with **no results _and_ a past end date** now reads "Finished" in the detail view instead of "Registration" (same bug class, now consistent). Events with results were already correct and stay correct.

Text-search stubs (no dates/state) resolve to `'unknown'` — shown under "All" but not matched by a specific status filter.

## Verification
`pnpm check` (typecheck, lint, test, build) passes — 65 tests.