### PR TITLE
Adopt SDK 0.7.0 status utilities; fix proxy 204→502; negative-cache missing players

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
-    "@msvens/schack-se-sdk": "github:msvens/schack-se-sdk#v0.6.1",
+    "@msvens/schack-se-sdk": "github:msvens/schack-se-sdk#v0.7.0",
     "leaflet": "^1.9.4",
     "leaflet.markercluster": "^1.5.3",
     "next": "16.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0(react@19.2.4)
       '@msvens/schack-se-sdk':
-        specifier: github:msvens/schack-se-sdk#v0.6.1
-        version: https://codeload.github.com/msvens/schack-se-sdk/tar.gz/833932572a336b6e129d62357c9a29f8c7b73b5e
+        specifier: github:msvens/schack-se-sdk#v0.7.0
+        version: https://codeload.github.com/msvens/schack-se-sdk/tar.gz/ef7fc09f023e3ad147a04c596ad3e2490aa2c6f6
       leaflet:
         specifier: ^1.9.4
         version: 1.9.4
@@ -634,9 +634,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@msvens/schack-se-sdk@https://codeload.github.com/msvens/schack-se-sdk/tar.gz/833932572a336b6e129d62357c9a29f8c7b73b5e':
-    resolution: {tarball: https://codeload.github.com/msvens/schack-se-sdk/tar.gz/833932572a336b6e129d62357c9a29f8c7b73b5e}
-    version: 0.6.1
+  '@msvens/schack-se-sdk@https://codeload.github.com/msvens/schack-se-sdk/tar.gz/ef7fc09f023e3ad147a04c596ad3e2490aa2c6f6':
+    resolution: {tarball: https://codeload.github.com/msvens/schack-se-sdk/tar.gz/ef7fc09f023e3ad147a04c596ad3e2490aa2c6f6}
+    version: 0.7.0
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -3358,7 +3358,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@msvens/schack-se-sdk@https://codeload.github.com/msvens/schack-se-sdk/tar.gz/833932572a336b6e129d62357c9a29f8c7b73b5e': {}
+  '@msvens/schack-se-sdk@https://codeload.github.com/msvens/schack-se-sdk/tar.gz/ef7fc09f023e3ad147a04c596ad3e2490aa2c6f6': {}
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:

--- a/src/app/api/chess/v1/[...path]/route.ts
+++ b/src/app/api/chess/v1/[...path]/route.ts
@@ -16,7 +16,11 @@ async function proxy(request: NextRequest) {
       body: request.method !== 'GET' ? await request.text() : undefined,
     });
 
-    const data = await response.text();
+    // 204/304 are null-body statuses — constructing a Response with a body for
+    // them throws, so pass null. (The SSF API returns 204 for "no data", e.g. a
+    // player with no rating at a given date; without this it became a spurious 502.)
+    const nullBody = response.status === 204 || response.status === 304;
+    const data = nullBody ? null : await response.text();
     return new Response(data, {
       status: response.status,
       headers: { 'Content-Type': response.headers.get('Content-Type') || 'application/json' },

--- a/src/app/api/chesstools/[...path]/route.ts
+++ b/src/app/api/chesstools/[...path]/route.ts
@@ -11,7 +11,10 @@ async function proxy(request: NextRequest) {
     const target = `${CHESSTOOLS_BASE}${originalPath}${search}`;
 
     const response = await fetch(target);
-    const data = await response.text();
+    // 204/304 are null-body statuses — passing a body to them throws (becoming a
+    // spurious 502); pass null instead.
+    const nullBody = response.status === 204 || response.status === 304;
+    const data = nullBody ? null : await response.text();
 
     return new Response(data, {
       status: response.status,

--- a/src/app/results/[tournamentId]/[groupId]/layout.tsx
+++ b/src/app/results/[tournamentId]/[groupId]/layout.tsx
@@ -2,7 +2,7 @@
 
 import { ReactNode, useState, useEffect, useMemo, useCallback } from 'react';
 import { useParams } from 'next/navigation';
-import { ResultsService, TournamentService, formatRatingWithType, getPlayerRatingStrict, getPlayerRatingByRoundType, formatPlayerName, getOpponentKind, TournamentEndResultDto, TournamentRoundResultDto, PlayerInfoDto, TeamTournamentEndResultDto, TournamentDto, RoundDto, isTeamTournament, isTeamPairing, findTournamentGroup } from '@/lib/api';
+import { ResultsService, TournamentService, formatRatingWithType, getPlayerRatingStrict, getPlayerRatingByRoundType, formatPlayerName, getOpponentKind, TournamentEndResultDto, TournamentRoundResultDto, PlayerInfoDto, TeamTournamentEndResultDto, TournamentDto, TournamentClassGroupDto, RoundDto, isTeamTournament, isTeamPairing, findTournamentGroup } from '@/lib/api';
 import { getTranslation } from '@/lib/translations';
 import { GroupResultsProvider, GroupResultsContextValue, PlayerDateRequest } from '@/context/GroupResultsContext';
 import { useOrganizations } from '@/context/OrganizationsContext';
@@ -20,6 +20,7 @@ export default function GroupResultsLayout({ children }: { children: ReactNode }
 
   // Tournament metadata
   const [tournament, setTournament] = useState<TournamentDto | null>(null);
+  const [group, setGroup] = useState<TournamentClassGroupDto | null>(null);
   const [thinkingTime, setThinkingTime] = useState<string | null>(null);
   const [groupName, setGroupName] = useState<string | null>(null);
   const [groupStartDate, setGroupStartDate] = useState<string | null>(null);
@@ -132,6 +133,7 @@ export default function GroupResultsLayout({ children }: { children: ReactNode }
       // Find the group metadata to get name, dates, and ranking algorithm
       const groupResult = findTournamentGroup(tournamentData, groupId);
       if (groupResult) {
+        setGroup(groupResult.group);
         setGroupName(groupResult.group.name);
         setGroupStartDate(groupResult.group.start);
         setGroupEndDate(groupResult.group.end);
@@ -321,6 +323,7 @@ export default function GroupResultsLayout({ children }: { children: ReactNode }
     groupEndDate,
     rankingAlgorithm,
     tournamentState: tournament?.state ?? null,
+    group,
     loading,
     error,
     getPlayerName,

--- a/src/app/results/[tournamentId]/[groupId]/page.tsx
+++ b/src/app/results/[tournamentId]/[groupId]/page.tsx
@@ -3,8 +3,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { PageLayout } from '@/components/layout/PageLayout';
-import { TournamentService, getResultDisplayString, normalizeEloLookupDate, parseLocalDate, getOpponentKind, isTeamPairing, isLooseTeamTournament, TournamentDto, TournamentClassDto, TournamentClassGroupDto, TournamentEndResultDto, TournamentRoundResultDto, TeamTournamentEndResultDto } from '@/lib/api';
-import { getTournamentStatus } from '@/lib/utils/tournamentFilters';
+import { TournamentService, getResultDisplayString, normalizeEloLookupDate, parseLocalDate, getOpponentKind, isTeamPairing, isLooseTeamTournament, TournamentDto, TournamentClassDto, TournamentClassGroupDto, TournamentEndResultDto, TournamentRoundResultDto, TeamTournamentEndResultDto, getTournamentStatus } from '@/lib/api';
 import { useLanguage } from '@/context/LanguageContext';
 import { getTranslation } from '@/lib/translations';
 import { useGroupResults, PlayerDateRequest } from '@/context/GroupResultsContext';
@@ -89,7 +88,7 @@ export default function GroupResultsPage() {
     rankingAlgorithm,
     groupStartDate,
     groupEndDate,
-    tournamentState,
+    group,
     loading: resultsLoading,
     error: resultsError,
     getPlayerName,
@@ -315,20 +314,16 @@ export default function GroupResultsPage() {
   // Determine tournament/group state for display
   // These are only used when resultsLoading is false (guarded in JSX)
   //
-  // hasRoundResults: round results existing proves games have been played,
-  // regardless of the (unreliable) API state.
-  const hasRoundResults = isTeamTournament
-    ? teamRoundResults.length > 0
-    : individualRoundResults.length > 0;
-
-  // Derive status from the same shared helper the results/calendar lists use,
-  // fed this group's dates + the round-results signal (see tournamentFilters.ts).
-  const status = getTournamentStatus({
-    start: groupStartDate,
-    end: groupEndDate,
-    state: tournamentState,
-    hasRoundResults,
-  });
+  // Derive status via the SDK helper (the same one the results/calendar lists
+  // use). Group dates take precedence over the tournament's; `tournament`
+  // supplies the (weak) state hint; a non-empty roundResults array proves the
+  // event has started — so a stale "registration" state can't mislabel it.
+  const roundResultsForStatus = isTeamTournament ? teamRoundResults : individualRoundResults;
+  const status = group
+    ? getTournamentStatus({ group, tournament: tournament ?? undefined, roundResults: roundResultsForStatus })
+    : tournament
+      ? getTournamentStatus({ tournament, roundResults: roundResultsForStatus })
+      : 'unknown';
   const isNotStarted = status === 'upcoming';
   const isFinished = status === 'finished';
 

--- a/src/components/player/HeadToHeadTab.tsx
+++ b/src/components/player/HeadToHeadTab.tsx
@@ -99,7 +99,9 @@ export function HeadToHeadTab({ opponentId, language }: HeadToHeadTabProps) {
   // Derive loading state: true if either player isn't in the cache yet
   const playersLoading = useMemo(() => {
     if (!memberId) return false;
-    return !globalCache.getPlayer(memberId) || !globalCache.getPlayer(opponentId);
+    // 'missing' (API confirmed no record) counts as resolved → show "unknown".
+    return globalCache.getPlayerStatus(memberId) === 'unfetched'
+      || globalCache.getPlayerStatus(opponentId) === 'unfetched';
   }, [memberId, opponentId, globalCache]);
 
   // Convert to display format

--- a/src/components/player/OpponentsTab.tsx
+++ b/src/components/player/OpponentsTab.tsx
@@ -79,7 +79,9 @@ export function OpponentsTab({ language }: OpponentsTabProps) {
     if (!memberId) return false;
     return filteredGames.some(game => {
       const opponentId = game.whiteId === memberId ? game.blackId : game.whiteId;
-      return opponentId > 0 && !globalCache.getPlayer(opponentId);
+      // 'missing' (API confirmed no record) counts as resolved → show "unknown",
+      // not a perpetual "retrieving".
+      return opponentId > 0 && globalCache.getPlayerStatus(opponentId) === 'unfetched';
     });
   }, [filteredGames, memberId, globalCache]);
 

--- a/src/context/GlobalPlayerCacheContext.tsx
+++ b/src/context/GlobalPlayerCacheContext.tsx
@@ -2,16 +2,25 @@
 
 import { createContext, useContext, useState, useCallback, useRef, ReactNode } from 'react';
 import { PlayerInfoDto, PlayerService, getPlayerDateCacheKey, normalizeEloLookupDate } from '@/lib/api';
+import { PlayerDateCache, type PlayerCacheStatus } from '@/lib/player/playerDateCache';
 
 export interface PlayerDateRequest {
   playerId: number;
   date: number; // timestamp in milliseconds
 }
 
+export type { PlayerCacheStatus };
+
 export interface GlobalPlayerCacheContextValue {
   // Sync lookups (cache-only, no API call)
   getPlayer(playerId: number): PlayerInfoDto | undefined;
   getPlayerByDate(playerId: number, date: number): PlayerInfoDto | undefined;
+  /**
+   * Tri-state cache status, so callers can tell "still loading" from "confirmed
+   * has no record" (the API returns 204/404 for the latter). `date` omitted =
+   * current month.
+   */
+  getPlayerStatus(playerId: number, date?: number): PlayerCacheStatus;
 
   // Async fetch methods (check cache first, only call API for misses)
   getOrFetchPlayer(playerId: number): Promise<PlayerInfoDto | undefined>;
@@ -31,9 +40,10 @@ export function useGlobalPlayerCache() {
 }
 
 export function GlobalPlayerCacheProvider({ children }: { children: ReactNode }) {
-  // Single unified cache keyed by "playerId-YYYY-MM-01"
-  // All lookups use a date (current date for "current" player, specific date for historical)
-  const playerCacheRef = useRef<Map<string, PlayerInfoDto>>(new Map());
+  // Single unified cache keyed by "playerId-YYYY-MM-01" (see PlayerDateCache for
+  // the negative-caching semantics). All lookups use a date — current date for
+  // the "current" player, a specific date for historical lookups.
+  const playerCacheRef = useRef<PlayerDateCache>(new PlayerDateCache());
   const [, setVersion] = useState(0);
 
   const bump = useCallback(() => setVersion(v => v + 1), []);
@@ -58,26 +68,28 @@ export function GlobalPlayerCacheProvider({ children }: { children: ReactNode })
   }, [getCurrentDateKey]);
 
   const getPlayerByDate = useCallback((playerId: number, date: number): PlayerInfoDto | undefined => {
-    const key = getPlayerDateCacheKey(playerId, normalizeEloLookupDate(date));
-    return playerCacheRef.current.get(key);
+    return playerCacheRef.current.get(getPlayerDateCacheKey(playerId, normalizeEloLookupDate(date)));
   }, []);
+
+  const getPlayerStatus = useCallback((playerId: number, date?: number): PlayerCacheStatus => {
+    const key = date !== undefined
+      ? getPlayerDateCacheKey(playerId, normalizeEloLookupDate(date))
+      : getCurrentDateKey(playerId);
+    return playerCacheRef.current.status(key);
+  }, [getCurrentDateKey]);
 
   // --- Async fetch methods ---
 
   const getOrFetchPlayer = useCallback(async (playerId: number): Promise<PlayerInfoDto | undefined> => {
     const normalizedDate = normalizeEloLookupDate(Date.now());
     const key = getPlayerDateCacheKey(playerId, normalizedDate);
-    const cached = playerCacheRef.current.get(key);
-    if (cached) return cached;
+    if (playerCacheRef.current.has(key)) return playerCacheRef.current.get(key);
 
     const service = getPlayerService();
     const response = await service.getPlayerInfo(playerId);
-    if (response.status === 200 && response.data) {
-      playerCacheRef.current.set(key, response.data);
-      bump();
-      return response.data;
-    }
-    return undefined;
+    playerCacheRef.current.setFromResult(key, response.status === 200 ? response.data : null);
+    bump();
+    return playerCacheRef.current.get(key);
   }, [getPlayerService, bump]);
 
   const getOrFetchPlayers = useCallback(async (playerIds: number[]): Promise<Map<number, PlayerInfoDto>> => {
@@ -87,9 +99,9 @@ export function GlobalPlayerCacheProvider({ children }: { children: ReactNode })
 
     for (const id of playerIds) {
       const key = getPlayerDateCacheKey(id, normalizedDate);
-      const cached = playerCacheRef.current.get(key);
-      if (cached) {
-        result.set(id, cached);
+      if (playerCacheRef.current.has(key)) {
+        const cached = playerCacheRef.current.get(key);
+        if (cached) result.set(id, cached); // negative entries stay out of the result
       } else {
         missingIds.push(id);
       }
@@ -100,12 +112,17 @@ export function GlobalPlayerCacheProvider({ children }: { children: ReactNode })
       // TODO: Switch to getPlayerList once the SSF API handles missing IDs
       // gracefully (currently POST /player/list/ returns 500 if any ID is unknown)
       const responses = await service.getPlayerInfoBatch(missingIds);
+      const returned = new Set<number>();
       responses.forEach(response => {
         if (response.data) {
-          const key = getPlayerDateCacheKey(response.data.id, normalizedDate);
-          playerCacheRef.current.set(key, response.data);
+          playerCacheRef.current.setFound(getPlayerDateCacheKey(response.data.id, normalizedDate), response.data);
           result.set(response.data.id, response.data);
+          returned.add(response.data.id);
         }
+      });
+      // Negative-cache any requested id the batch didn't return, so we stop refetching it.
+      missingIds.forEach(id => {
+        if (!returned.has(id)) playerCacheRef.current.setMissing(getPlayerDateCacheKey(id, normalizedDate));
       });
       bump();
     }
@@ -116,18 +133,13 @@ export function GlobalPlayerCacheProvider({ children }: { children: ReactNode })
   const getOrFetchPlayerByDate = useCallback(async (playerId: number, date: number): Promise<PlayerInfoDto | undefined> => {
     const normalizedDate = normalizeEloLookupDate(date);
     const key = getPlayerDateCacheKey(playerId, normalizedDate);
-    const cached = playerCacheRef.current.get(key);
-    if (cached) return cached;
+    if (playerCacheRef.current.has(key)) return playerCacheRef.current.get(key);
 
     const service = getPlayerService();
-    const dateObj = new Date(normalizedDate);
-    const response = await service.getPlayerInfo(playerId, dateObj);
-    if (response.status === 200 && response.data) {
-      playerCacheRef.current.set(key, response.data);
-      bump();
-      return response.data;
-    }
-    return undefined;
+    const response = await service.getPlayerInfo(playerId, new Date(normalizedDate));
+    playerCacheRef.current.setFromResult(key, response.status === 200 ? response.data : null);
+    bump();
+    return playerCacheRef.current.get(key);
   }, [getPlayerService, bump]);
 
   const getOrFetchPlayersByDate = useCallback(async (requests: PlayerDateRequest[]): Promise<void> => {
@@ -149,21 +161,21 @@ export function GlobalPlayerCacheProvider({ children }: { children: ReactNode })
       missing.map(req => service.getPlayerInfo(req.playerId, new Date(req.date)))
     );
 
-    let added = false;
     responses.forEach((response, index) => {
-      if (response.status === 'fulfilled' && response.value.status === 200 && response.value.data) {
-        const key = getPlayerDateCacheKey(missing[index].playerId, missing[index].date);
-        playerCacheRef.current.set(key, response.value.data);
-        added = true;
-      }
+      const key = getPlayerDateCacheKey(missing[index].playerId, missing[index].date);
+      // Negative-cache failures/no-data too, so we don't refetch them.
+      const data =
+        response.status === 'fulfilled' && response.value.status === 200 ? response.value.data : null;
+      playerCacheRef.current.setFromResult(key, data);
     });
 
-    if (added) bump();
+    bump();
   }, [getPlayerService, bump]);
 
   const value: GlobalPlayerCacheContextValue = {
     getPlayer,
     getPlayerByDate,
+    getPlayerStatus,
     getOrFetchPlayer,
     getOrFetchPlayers,
     getOrFetchPlayerByDate,

--- a/src/context/GroupResultsContext.tsx
+++ b/src/context/GroupResultsContext.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { createContext, useContext } from 'react';
-import { TournamentEndResultDto, TournamentRoundResultDto, PlayerInfoDto, TeamTournamentEndResultDto, RoundDto } from '@/lib/api';
+import { TournamentClassGroupDto, TournamentEndResultDto, TournamentRoundResultDto, PlayerInfoDto, TeamTournamentEndResultDto, RoundDto } from '@/lib/api';
 
 /**
  * Request for fetching a player's info at a specific historical date
@@ -31,6 +31,8 @@ export interface GroupResultsContextValue {
   groupEndDate: string | null;
   rankingAlgorithm: number | null;
   tournamentState: number | null;
+  /** Raw group DTO for SDK status derivation (getTournamentStatus). */
+  group: TournamentClassGroupDto | null;
   loading: boolean;
   error: string | null;
 

--- a/src/lib/player/__tests__/playerDateCache.test.ts
+++ b/src/lib/player/__tests__/playerDateCache.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { PlayerDateCache } from '@/lib/player/playerDateCache';
+import type { PlayerInfoDto } from '@/lib/api';
+
+const player = (id: number) => ({ id, firstName: 'A', lastName: 'B' } as unknown as PlayerInfoDto);
+const K = 'p1-2025-06-01';
+
+describe('PlayerDateCache', () => {
+  it('starts unfetched: no hit, no player, status unfetched', () => {
+    const c = new PlayerDateCache();
+    expect(c.has(K)).toBe(false);
+    expect(c.get(K)).toBeUndefined();
+    expect(c.status(K)).toBe('unfetched');
+  });
+
+  it('setFound: hit, returns the player, status found', () => {
+    const c = new PlayerDateCache();
+    c.setFound(K, player(1));
+    expect(c.has(K)).toBe(true);
+    expect(c.get(K)?.id).toBe(1);
+    expect(c.status(K)).toBe('found');
+  });
+
+  it('setMissing negatively caches: still a HIT (so callers do not refetch), but no player', () => {
+    const c = new PlayerDateCache();
+    c.setMissing(K);
+    expect(c.has(K)).toBe(true); // the whole point: a confirmed-missing key is a cache hit
+    expect(c.get(K)).toBeUndefined();
+    expect(c.status(K)).toBe('missing');
+  });
+
+  it('distinguishes the three states — the bug was conflating missing with unfetched', () => {
+    const c = new PlayerDateCache();
+    expect(c.status('unfetched-key')).toBe('unfetched');
+    c.setMissing('missing-key');
+    c.setFound('found-key', player(2));
+    expect(c.status('missing-key')).toBe('missing');
+    expect(c.status('found-key')).toBe('found');
+  });
+
+  it('setFromResult: data → found, null/undefined → missing', () => {
+    const c = new PlayerDateCache();
+    c.setFromResult('a', player(3));
+    c.setFromResult('b', null);
+    c.setFromResult('c', undefined);
+    expect(c.status('a')).toBe('found');
+    expect(c.status('b')).toBe('missing');
+    expect(c.status('c')).toBe('missing');
+  });
+
+  it('get collapses a negative entry to undefined (same shape as a real miss for callers)', () => {
+    const c = new PlayerDateCache();
+    c.setMissing(K);
+    expect(c.get(K)).toBeUndefined();
+  });
+});

--- a/src/lib/player/playerDateCache.ts
+++ b/src/lib/player/playerDateCache.ts
@@ -1,0 +1,48 @@
+import type { PlayerInfoDto } from '@/lib/api';
+
+/** Cache state for a player(+date): not fetched, confirmed missing, or found. */
+export type PlayerCacheStatus = 'unfetched' | 'missing' | 'found';
+
+/**
+ * Plain (React-free) store backing GlobalPlayerCacheContext, keyed by the SDK's
+ * "playerId-YYYY-MM-01" strings.
+ *
+ * A `null` entry is a NEGATIVE cache: the API confirmed there is no record
+ * (it returns 204/404, e.g. a player with no rating at a given date). Recording
+ * that — rather than leaving the key absent — is what stops the app from
+ * refetching the same missing player forever, and lets the UI show "unknown"
+ * instead of a perpetual "retrieving".
+ */
+export class PlayerDateCache {
+  private readonly entries = new Map<string, PlayerInfoDto | null>();
+
+  /** A key is a cache hit whether it resolved to a player OR to "missing". */
+  has(key: string): boolean {
+    return this.entries.has(key);
+  }
+
+  /** The player, or undefined for both "unfetched" and "confirmed missing". */
+  get(key: string): PlayerInfoDto | undefined {
+    return this.entries.get(key) ?? undefined;
+  }
+
+  status(key: string): PlayerCacheStatus {
+    if (!this.entries.has(key)) return 'unfetched';
+    return this.entries.get(key) ? 'found' : 'missing';
+  }
+
+  setFound(key: string, player: PlayerInfoDto): void {
+    this.entries.set(key, player);
+  }
+
+  /** Negative-cache: record that this key has no record so we don't refetch. */
+  setMissing(key: string): void {
+    this.entries.set(key, null);
+  }
+
+  /** setFound when data is present, setMissing otherwise. */
+  setFromResult(key: string, player: PlayerInfoDto | null | undefined): void {
+    if (player) this.setFound(key, player);
+    else this.setMissing(key);
+  }
+}

--- a/src/lib/utils/__tests__/tournamentFilters.test.ts
+++ b/src/lib/utils/__tests__/tournamentFilters.test.ts
@@ -7,7 +7,6 @@ import {
   filterByCategory,
   filterByType,
   filterByState,
-  getTournamentStatus,
   getAllTournamentTypes,
   getTournamentTypeKey,
 } from '@/lib/utils/tournamentFilters';
@@ -91,57 +90,14 @@ describe('countByType', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// getTournamentStatus  (date-first; state is only a weak hint)
-// ---------------------------------------------------------------------------
-describe('getTournamentStatus', () => {
-  const now = new Date('2025-06-15T12:00:00');
-
-  it('finished when past the end date', () => {
-    expect(getTournamentStatus({ start: '2025-06-01', end: '2025-06-10' }, now)).toBe('finished');
-  });
-
-  it('upcoming when before the start date', () => {
-    expect(getTournamentStatus({ start: '2025-07-01', end: '2025-07-02' }, now)).toBe('upcoming');
-  });
-
-  it('ongoing when inside the date window', () => {
-    expect(getTournamentStatus({ start: '2025-06-01', end: '2025-06-30' }, now)).toBe('ongoing');
-  });
-
-  it('THE BUG: stale state=registration on a past event is still finished', () => {
-    expect(
-      getTournamentStatus({ start: '2025-01-01', end: '2025-01-02', state: TournamentState.REGISTRATION }, now),
-    ).toBe('finished');
-  });
-
-  it('honours an explicit registration state inside the window (no results yet)', () => {
-    expect(
-      getTournamentStatus({ start: '2025-06-01', end: '2025-06-30', state: TournamentState.REGISTRATION }, now),
-    ).toBe('upcoming');
-  });
-
-  it('round results prove it started: ongoing while in window, finished once past end', () => {
-    expect(getTournamentStatus({ end: '2025-06-30', hasRoundResults: true }, now)).toBe('ongoing');
-    expect(getTournamentStatus({ end: '2025-06-01', hasRoundResults: true }, now)).toBe('finished');
-  });
-
-  it('treats the last day (today === end) as ongoing, not finished', () => {
-    expect(getTournamentStatus({ start: '2025-06-01', end: '2025-06-15' }, now)).toBe('ongoing');
-  });
-
-  it('falls back to raw state when no dates are present', () => {
-    expect(getTournamentStatus({ state: TournamentState.STARTED }, now)).toBe('ongoing');
-    expect(getTournamentStatus({ state: TournamentState.FINISHED }, now)).toBe('finished');
-  });
-
-  it('unknown when neither dates nor a usable state are available (e.g. text-search stub)', () => {
-    expect(getTournamentStatus({ start: '', end: '', state: 0 }, now)).toBe('unknown');
-  });
-});
+// Note: the date-derived status logic itself now lives in the SDK
+// (`getTournamentStatus`) and is tested there. The countByState/filterByState
+// tests below remain as the app-level guard that our bucketing/mapping still
+// derives correctly through the SDK (and that the original stale-state bug
+// stays fixed end-to-end).
 
 // ---------------------------------------------------------------------------
-// countByState  (now derives status from dates: registration=upcoming, started=ongoing)
+// countByState  (derives status via the SDK: registration=upcoming, started=ongoing)
 // ---------------------------------------------------------------------------
 describe('countByState', () => {
   it('buckets by derived status, ignoring the stale state field', () => {

--- a/src/lib/utils/tournamentFilters.ts
+++ b/src/lib/utils/tournamentFilters.ts
@@ -3,12 +3,20 @@
  *
  * Status note: the API `state` field is unreliable — organizers routinely never
  * flip it from "registration" once an event has happened, so old finished
- * tournaments still report state=1. We therefore derive status from DATES
- * (`getTournamentStatus`) and treat `state` only as a weak hint. The detail
- * view uses the same helper, so list and detail agree.
+ * tournaments still report state=1. Status is therefore derived from DATES via
+ * the SDK's `getTournamentStatus` (treats `state` only as a weak hint); the
+ * count/filter helpers below just bucket that per-tournament status for the
+ * filter UI. The detail view calls the same SDK helper, so list and detail agree.
  */
 
-import { TournamentDto, TournamentType, TournamentState, isTeamTournament, parseLocalDate } from '@/lib/api';
+import {
+  TournamentDto,
+  TournamentType,
+  TournamentState,
+  isTeamTournament,
+  getTournamentStatus,
+  type TournamentStatus,
+} from '@/lib/api';
 
 // =============================================================================
 // Types
@@ -30,58 +38,6 @@ export interface StateCounts {
 }
 
 export type TypeCounts = Record<number | 'all', number>;
-
-/** Derived tournament status (from dates, not the unreliable API `state`). */
-export type TournamentStatus = 'upcoming' | 'ongoing' | 'finished' | 'unknown';
-
-export interface TournamentStatusInput {
-  /** YYYY-MM-DD start date (tournament- or group-level). */
-  start?: string | null;
-  /** YYYY-MM-DD end date (tournament- or group-level). */
-  end?: string | null;
-  /** Raw API state — used only as a weak hint when dates can't decide. */
-  state?: number | null;
-  /** True if any round results exist — proves the event has started. */
-  hasRoundResults?: boolean;
-}
-
-/**
- * Derive a tournament's status, trusting DATES over the API `state` field.
- *
- * Order matters: a past end date wins over `state` (that's what fixes the
- * stale-"registration" bug). Round results, when known, prove the event has
- * started. `state` is consulted only inside the date window or when no dates
- * are available at all (e.g. text-search stubs → `unknown`).
- */
-export function getTournamentStatus(t: TournamentStatusInput, now: Date = new Date()): TournamentStatus {
-  const today = new Date(now);
-  today.setHours(0, 0, 0, 0);
-  const todayMs = today.getTime();
-
-  const toMs = (d?: string | null): number | null => {
-    if (!d) return null;
-    const parsed = parseLocalDate(d).getTime();
-    return Number.isNaN(parsed) ? null : parsed;
-  };
-  const startMs = toMs(t.start);
-  const endMs = toMs(t.end);
-
-  // Results exist → it has started; finished only once past the end date.
-  if (t.hasRoundResults) {
-    return endMs !== null && todayMs > endMs ? 'finished' : 'ongoing';
-  }
-  // Past the end date → finished, regardless of the (unreliable) state field.
-  if (endMs !== null && todayMs > endMs) return 'finished';
-  // Before the start date → upcoming.
-  if (startMs !== null && todayMs < startMs) return 'upcoming';
-  // Inside the date window: honour an explicit registration state if present.
-  if (t.state === TournamentState.REGISTRATION) return 'upcoming';
-  if (startMs !== null || endMs !== null) return 'ongoing';
-  // No dates at all: fall back to the raw state, else unknown.
-  if (t.state === TournamentState.STARTED) return 'ongoing';
-  if (t.state === TournamentState.FINISHED) return 'finished';
-  return 'unknown';
-}
 
 // =============================================================================
 // Count Functions


### PR DESCRIPTION
Three related changes, one per commit.

## 1. Adopt SDK 0.7.0 tournament-status utilities
Bumps `@msvens/schack-se-sdk` to **v0.7.0** and replaces our app-local `getTournamentStatus` with the SDK's — the date-derived "is it finished / ongoing / upcoming" logic (which works around the unreliable API `state` field) now lives in one place for every consumer.

- `countByState`/`filterByState` derive via the SDK helper (kept as app-level filter-UI aggregation); deleted our duplicate helper + `TournamentStatus`/`TournamentStatusInput`.
- Detail view calls the SDK helper with the group + tournament DTOs + fetched round results; `GroupResultsContext` now exposes the group DTO.
- Dropped our `getTournamentStatus` unit tests (logic + tests are in the SDK); kept the `countByState`/`filterByState` tests as the end-to-end guard.

Purely additive SDK upgrade (no other breaking changes). Behavior is identical to before — this is a consolidation, not a behavior change.

## 2. Fix proxy turning upstream 204/304 into a spurious 502
`204`/`304` are null-body statuses — building a `Response` with a body for them throws, and the proxy's `catch` downgraded that to **502**. The SSF API returns `204` for "no data" (e.g. a player with no rating at a given date), so clean responses surfaced as gateway errors and triggered needless retries. Both the chess and chesstools proxies now pass a `null` body for null-body statuses.

## 3. Negative-cache players with no record; show "unknown" not "retrieving"
The player cache only stored results on HTTP 200, so a player/date with no record was never recorded and got **refetched on every render**. The UI also couldn't tell "still loading" from "confirmed missing", so it showed **"retrieving"** indefinitely.

- Extracted a plain, React-free `PlayerDateCache` (a `null` entry is a negative cache — a missing key is still a *hit*, so we stop refetching) and backed `GlobalPlayerCacheContext` with it.
- Added `getPlayerStatus → 'unfetched' | 'missing' | 'found'`; the Opponents/Head-to-head tabs treat `'missing'` as resolved, so confirmed-missing players render the existing **"unknown"/"okänd"** label instead of a perpetual "retrieving".
- Unit-tested the cache (regression guard for the missing-as-a-hit semantics) — no new test infra, runs under the existing node setup.

## Verification
`pnpm check` (typecheck, lint, **62 tests**, build) passes. Manual: reloading a team tournament with a no-data player fires the `player/.../date/...` call once (204, no repeat); unresolved opponents settle on "unknown".

Does **not** include the pending `public/data/{clubs-by-district,districts,organizations-all}.json` refresh — kept separate as before.