### PR TITLE
Round-by-round standings playback

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
-    "@msvens/schack-se-sdk": "github:msvens/schack-se-sdk#v0.7.0",
+    "@msvens/schack-se-sdk": "github:msvens/schack-se-sdk#v0.8.0",
     "leaflet": "^1.9.4",
     "leaflet.markercluster": "^1.5.3",
     "next": "16.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0(react@19.2.4)
       '@msvens/schack-se-sdk':
-        specifier: github:msvens/schack-se-sdk#v0.7.0
-        version: https://codeload.github.com/msvens/schack-se-sdk/tar.gz/ef7fc09f023e3ad147a04c596ad3e2490aa2c6f6
+        specifier: github:msvens/schack-se-sdk#v0.8.0
+        version: https://codeload.github.com/msvens/schack-se-sdk/tar.gz/8309ada7e3e7a6130d63814f64fbbf2a26c2ab64
       leaflet:
         specifier: ^1.9.4
         version: 1.9.4
@@ -634,9 +634,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@msvens/schack-se-sdk@https://codeload.github.com/msvens/schack-se-sdk/tar.gz/ef7fc09f023e3ad147a04c596ad3e2490aa2c6f6':
-    resolution: {tarball: https://codeload.github.com/msvens/schack-se-sdk/tar.gz/ef7fc09f023e3ad147a04c596ad3e2490aa2c6f6}
-    version: 0.7.0
+  '@msvens/schack-se-sdk@https://codeload.github.com/msvens/schack-se-sdk/tar.gz/8309ada7e3e7a6130d63814f64fbbf2a26c2ab64':
+    resolution: {tarball: https://codeload.github.com/msvens/schack-se-sdk/tar.gz/8309ada7e3e7a6130d63814f64fbbf2a26c2ab64}
+    version: 0.8.0
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -3358,7 +3358,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@msvens/schack-se-sdk@https://codeload.github.com/msvens/schack-se-sdk/tar.gz/ef7fc09f023e3ad147a04c596ad3e2490aa2c6f6': {}
+  '@msvens/schack-se-sdk@https://codeload.github.com/msvens/schack-se-sdk/tar.gz/8309ada7e3e7a6130d63814f64fbbf2a26c2ab64': {}
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:

--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -2,23 +2,22 @@
 
 import { PageLayout } from '@/components/layout/PageLayout';
 import { Card } from '@/components/Card';
+import { Badge, BadgeColor } from '@/components/Badge';
 import { changelog, ChangelogEntry, ChangelogSection } from '@/data/changelog';
 
 function SectionBadge({ type }: { type: string }) {
-  const colors: Record<string, string> = {
-    Added: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
-    Changed: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
-    Fixed: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
-    Removed: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
-    Infrastructure: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400',
+  const colors: Record<string, BadgeColor> = {
+    Added: 'green',
+    Changed: 'blue',
+    Fixed: 'yellow',
+    Removed: 'red',
+    Infrastructure: 'purple',
   };
 
-  const colorClass = colors[type] || 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-400';
-
   return (
-    <span className={`inline-block px-2 py-0.5 text-xs font-medium rounded ${colorClass}`}>
+    <Badge color={colors[type] || 'gray'} shape="rounded">
       {type}
-    </span>
+    </Badge>
   );
 }
 

--- a/src/app/results/[tournamentId]/[groupId]/page.tsx
+++ b/src/app/results/[tournamentId]/[groupId]/page.tsx
@@ -466,6 +466,13 @@ export default function GroupResultsPage() {
     }
   };
 
+  // Enabling playback starts from round 1 so the user scrubs forward through the
+  // event (the shared round state otherwise defaults to the latest round).
+  const handlePlaybackToggle = (checked: boolean) => {
+    setPlaybackEnabled(checked);
+    if (checked && sortedRounds.length > 0) setSelectedRound(sortedRounds[0]);
+  };
+
   // Handle class selection - navigate to first group in that class
   const handleClassSelect = (id: string | number) => {
     const selectedClass = allClasses.find(c => c.classID === id);
@@ -641,7 +648,7 @@ export default function GroupResultsPage() {
                             {playbackEligible && (
                               <Toggle
                                 checked={playbackEnabled}
-                                onChange={setPlaybackEnabled}
+                                onChange={handlePlaybackToggle}
                                 label={t.pages.tournamentResults.standingsPlayback.toggleLabel}
                               />
                             )}

--- a/src/app/results/[tournamentId]/[groupId]/page.tsx
+++ b/src/app/results/[tournamentId]/[groupId]/page.tsx
@@ -3,16 +3,21 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { PageLayout } from '@/components/layout/PageLayout';
-import { TournamentService, getResultDisplayString, normalizeEloLookupDate, parseLocalDate, getOpponentKind, isTeamPairing, isLooseTeamTournament, TournamentDto, TournamentClassDto, TournamentClassGroupDto, TournamentEndResultDto, TournamentRoundResultDto, TeamTournamentEndResultDto, getTournamentStatus } from '@/lib/api';
+import { TournamentService, ResultsService, getResultDisplayString, normalizeEloLookupDate, parseLocalDate, getOpponentKind, isTeamPairing, isLooseTeamTournament, getTiebreakSystemName, createTeamNameFormatter, TournamentDto, TournamentClassDto, TournamentClassGroupDto, TournamentEndResultDto, TournamentRoundResultDto, TeamTournamentEndResultDto, RoundStandings, RoundStandingRow, getTournamentStatus } from '@/lib/api';
 import { useLanguage } from '@/context/LanguageContext';
 import { getTranslation } from '@/lib/translations';
 import { useGroupResults, PlayerDateRequest } from '@/context/GroupResultsContext';
 import { FinalResultsTable } from '@/components/results/FinalResultsTable';
 import { TeamFinalResultsTable } from '@/components/results/TeamFinalResultsTable';
 import { RegistrationTable } from '@/components/results/RegistrationTable';
+import { RoundStandingsTable } from '@/components/results/RoundStandingsTable';
+import { TeamRoundStandingsTable } from '@/components/results/TeamRoundStandingsTable';
+import { RoundStepper } from '@/components/results/RoundStepper';
 import { TeamRoundResults } from '@/components/results/TeamRoundResults';
 import { LiveUpdatesToggle } from '@/components/results/LiveUpdatesToggle';
 import { SelectableList, SelectableListItem } from '@/components/SelectableList';
+import { Toggle } from '@/components/Toggle';
+import { Badge } from '@/components/Badge';
 import { Link } from '@/components/Link';
 import { Table, TableColumn } from '@/components/Table';
 import { useLiveUpdates } from '@/hooks';
@@ -86,6 +91,7 @@ export default function GroupResultsPage() {
     teamRoundResults,
     thinkingTime,
     rankingAlgorithm,
+    playerMap,
     groupStartDate,
     groupEndDate,
     group,
@@ -118,6 +124,15 @@ export default function GroupResultsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedRound, setSelectedRound] = useState<number | null>(null);
+
+  // Opt-in round-by-round standings playback (never the default — official
+  // standings always show otherwise). Snapshots are fetched lazily the first
+  // time the toggle is enabled, so they cost nothing for the common case.
+  const [playbackEnabled, setPlaybackEnabled] = useState(false);
+  // Tagged with the groupId the snapshots belong to, so switching group refetches.
+  const [roundStandings, setRoundStandings] = useState<{ groupId: number; byRound: Map<number, RoundStandings> } | null>(null);
+  const [playbackLoading, setPlaybackLoading] = useState(false);
+  const [playbackError, setPlaybackError] = useState(false);
 
   const tournamentId = params.tournamentId ? parseInt(params.tournamentId as string) : null;
   const groupId = params.groupId ? parseInt(params.groupId as string) : null;
@@ -175,6 +190,42 @@ export default function GroupResultsPage() {
       fetchPlayersByDate(requests);
     }
   }, [isTeamTournament, activeRound, resultsByRound, resultsLoading, fetchPlayersByDate]);
+
+  // Lazily fetch round-by-round standings when playback is enabled (once per
+  // group). NOTE: `playbackLoading` must NOT be a dependency — toggling it would
+  // re-run the effect and its cleanup would cancel the in-flight request, leaving
+  // the loading flag stuck on forever.
+  useEffect(() => {
+    if (!playbackEnabled || groupId == null || roundStandings?.groupId === groupId) return;
+
+    let cancelled = false;
+    const run = () => {
+      setPlaybackLoading(true);
+      setPlaybackError(false);
+      new ResultsService()
+        .getRoundStandings(groupId)
+        .then((resp) => {
+          if (cancelled) return;
+          if (resp.status === 200 && resp.data) {
+            const byRound = new Map<number, RoundStandings>();
+            resp.data.forEach((snapshot) => byRound.set(snapshot.round, snapshot));
+            setRoundStandings({ groupId, byRound });
+          } else {
+            setPlaybackError(true);
+          }
+        })
+        .catch(() => {
+          if (!cancelled) setPlaybackError(true);
+        })
+        .finally(() => {
+          if (!cancelled) setPlaybackLoading(false);
+        });
+    };
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, [playbackEnabled, groupId, roundStandings]);
 
   useEffect(() => {
     if (!tournamentId || isNaN(tournamentId)) {
@@ -272,6 +323,14 @@ export default function GroupResultsPage() {
     }));
   }, [selectedClass]);
 
+  // Team-name formatter for the team playback snapshot, built from the official
+  // team standings so multi-team Roman numerals match the final table. (Declared
+  // before the early returns to keep hook order stable.)
+  const formatTeamName = useMemo(
+    () => createTeamNameFormatter(teamResults, getClubName),
+    [teamResults, getClubName]
+  );
+
   // Don't show loading message - it causes a brief flash on navigation
   // The content will appear once tournament data is loaded
   if (loading) {
@@ -355,6 +414,32 @@ export default function GroupResultsPage() {
     : false;
   const externalUrl = `https://resultat.schack.se/ShowTournamentServlet?id=${groupId}`;
 
+  // Round-by-round standings playback eligibility. Restricted to FINISHED events
+  // on purpose: during an ongoing event the live-updates toggle occupies this
+  // same spot, and a playback toggle beside it (live-now vs. scrub-history) is
+  // confusing — gating to finished means the two never coexist. Also excludes the
+  // degraded formats (individually-paired team, loose team) which hide standings.
+  const hasStandings = isTeamTournament ? teamResults.length > 0 : groupResults.length > 0;
+  const playbackEligible =
+    isFinished &&
+    !isIndividuallyPairedTeam &&
+    !isLooseTeam &&
+    hasStandings &&
+    sortedRounds.length >= 2;
+
+  // The estimated snapshot for the round currently being viewed (playback on).
+  const activeSnapshot =
+    playbackEnabled && roundStandings?.groupId === groupId && activeRound != null
+      ? roundStandings.byRound.get(activeRound) ?? null
+      : null;
+  const showPlayback = playbackEligible && playbackEnabled;
+  const tiebreakName = group ? getTiebreakSystemName(group.tiebreakSystem) : '';
+  // Explicit caveat copy — shown both as the "estimated" badge tooltip and as a
+  // visible note under the snapshot table.
+  const playbackNote = isTeamTournament
+    ? t.pages.tournamentResults.standingsPlayback.noteTeam
+    : t.pages.tournamentResults.standingsPlayback.noteIndividual.replace('{system}', tiebreakName);
+
   // Handle row click in final results table - navigate to player detail page
   const handlePlayerClick = (result: TournamentEndResultDto) => {
     if (result.playerInfo?.id && tournamentId && groupId) {
@@ -366,6 +451,18 @@ export default function GroupResultsPage() {
   const handleTeamClick = (result: TeamTournamentEndResultDto) => {
     if (result.contenderId && tournamentId && groupId) {
       router.push(`/results/${tournamentId}/${groupId}/team/${result.contenderId}-${result.teamNumber}`);
+    }
+  };
+
+  // Row clicks in the playback snapshot tables (rows carry only contenderId).
+  const handleSnapshotPlayerClick = (row: RoundStandingRow) => {
+    if (row.contenderId && tournamentId && groupId) {
+      router.push(`/results/${tournamentId}/${groupId}/${row.contenderId}`);
+    }
+  };
+  const handleSnapshotTeamClick = (row: RoundStandingRow) => {
+    if (row.contenderId && tournamentId && groupId) {
+      router.push(`/results/${tournamentId}/${groupId}/team/${row.contenderId}-${row.teamNumber}`);
     }
   };
 
@@ -502,11 +599,21 @@ export default function GroupResultsPage() {
                       <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-2">
                         <div>
                           <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-200">
-                            {isNotStarted
-                              ? t.pages.tournamentResults.registrationTable.title
-                              : isFinished
-                                ? t.pages.tournamentResults.finalResults
-                                : t.pages.tournamentResults.ongoingResults}{!isSingleGroup && ` - ${selectedGroup.name}`}
+                            {showPlayback
+                              ? t.pages.tournamentResults.standingsPlayback.titleTemplate.replace(
+                                  '{round}',
+                                  String(activeRound ?? sortedRounds[sortedRounds.length - 1])
+                                )
+                              : isNotStarted
+                                ? t.pages.tournamentResults.registrationTable.title
+                                : isFinished
+                                  ? t.pages.tournamentResults.finalResults
+                                  : t.pages.tournamentResults.ongoingResults}{!isSingleGroup && ` - ${selectedGroup.name}`}
+                            {showPlayback && (
+                              <Badge color="amber" tooltip={playbackNote} className="ml-2">
+                                {t.pages.tournamentResults.standingsPlayback.estimatedBadge}
+                              </Badge>
+                            )}
                           </h3>
                           {isNotStarted && groupStartDate && (
                             <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
@@ -519,16 +626,25 @@ export default function GroupResultsPage() {
                             </p>
                           )}
                         </div>
-                        {/* Live controls: only show for non-finished tournaments */}
-                        {!isFinished && (
-                          <div className="sm:flex-shrink-0">
-                            <LiveUpdatesToggle
-                              enabled={liveState.enabled}
-                              onToggle={setLiveEnabled}
-                              lastUpdated={liveState.lastUpdated || lastUpdated}
-                              isRefreshing={liveState.isRefreshing}
-                              onManualRefresh={manualRefresh}
-                            />
+                        {/* Right-side controls: live updates (non-finished) + standings playback (opt-in) */}
+                        {(!isFinished || playbackEligible) && (
+                          <div className="sm:flex-shrink-0 flex flex-col items-start sm:items-end gap-2">
+                            {!isFinished && (
+                              <LiveUpdatesToggle
+                                enabled={liveState.enabled}
+                                onToggle={setLiveEnabled}
+                                lastUpdated={liveState.lastUpdated || lastUpdated}
+                                isRefreshing={liveState.isRefreshing}
+                                onManualRefresh={manualRefresh}
+                              />
+                            )}
+                            {playbackEligible && (
+                              <Toggle
+                                checked={playbackEnabled}
+                                onChange={setPlaybackEnabled}
+                                label={t.pages.tournamentResults.standingsPlayback.toggleLabel}
+                              />
+                            )}
                           </div>
                         )}
                       </div>
@@ -593,35 +709,78 @@ export default function GroupResultsPage() {
                       // While loading, don't show any table - just wait
                       // This prevents flashing wrong content before we know the tournament state
                       null
-                    ) : isTeamTournament ? (
-                      (teamResults.length > 0 || resultsError) && (
-                        <TeamFinalResultsTable
-                          results={teamResults}
-                          getClubName={getClubName}
-                          loading={false}
-                          error={resultsError || undefined}
-                          onRowClick={handleTeamClick}
+                    ) : showPlayback && !playbackError ? (
+                      // Opt-in playback: estimated standings as of the selected round.
+                      <div>
+                        <RoundStepper
+                          rounds={sortedRounds}
+                          value={activeRound ?? sortedRounds[sortedRounds.length - 1]}
+                          onChange={setSelectedRound}
+                          labelPrefix={t.pages.tournamentResults.roundByRound.round}
+                          prevLabel={t.pages.tournamentResults.standingsPlayback.prevRound}
+                          nextLabel={t.pages.tournamentResults.standingsPlayback.nextRound}
+                          className="mb-4"
                         />
-                      )
-                    ) : isNotStarted ? (
-                      // Always show RegistrationTable for non-started tournaments
-                      <RegistrationTable
-                        results={groupResults}
-                        rankingAlgorithm={rankingAlgorithm}
-                        loading={false}
-                        error={resultsError || undefined}
-                        onRowClick={handlePlayerClick}
-                      />
+                        {playbackLoading && !activeSnapshot ? (
+                          <div className="p-8 text-center text-gray-600 dark:text-gray-400">
+                            {t.pages.tournamentResults.loading}
+                          </div>
+                        ) : isTeamTournament ? (
+                          <TeamRoundStandingsTable
+                            rows={activeSnapshot?.rows ?? []}
+                            formatTeamName={formatTeamName}
+                            onRowClick={handleSnapshotTeamClick}
+                          />
+                        ) : (
+                          <RoundStandingsTable
+                            rows={activeSnapshot?.rows ?? []}
+                            playerMap={playerMap}
+                            rankingAlgorithm={rankingAlgorithm}
+                            onRowClick={handleSnapshotPlayerClick}
+                          />
+                        )}
+                        <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
+                          {playbackNote}
+                        </p>
+                      </div>
                     ) : (
-                      (groupResults.length > 0 || resultsError) && (
-                        <FinalResultsTable
-                          results={groupResults}
-                          rankingAlgorithm={rankingAlgorithm}
-                          loading={false}
-                          error={resultsError || undefined}
-                          onRowClick={handlePlayerClick}
-                        />
-                      )
+                      <>
+                        {playbackEnabled && playbackError && (
+                          <p className="mb-3 text-xs text-amber-600 dark:text-amber-400">
+                            {t.pages.tournamentResults.standingsPlayback.loadError}
+                          </p>
+                        )}
+                        {isTeamTournament ? (
+                          (teamResults.length > 0 || resultsError) && (
+                            <TeamFinalResultsTable
+                              results={teamResults}
+                              getClubName={getClubName}
+                              loading={false}
+                              error={resultsError || undefined}
+                              onRowClick={handleTeamClick}
+                            />
+                          )
+                        ) : isNotStarted ? (
+                          // Always show RegistrationTable for non-started tournaments
+                          <RegistrationTable
+                            results={groupResults}
+                            rankingAlgorithm={rankingAlgorithm}
+                            loading={false}
+                            error={resultsError || undefined}
+                            onRowClick={handlePlayerClick}
+                          />
+                        ) : (
+                          (groupResults.length > 0 || resultsError) && (
+                            <FinalResultsTable
+                              results={groupResults}
+                              rankingAlgorithm={rankingAlgorithm}
+                              loading={false}
+                              error={resultsError || undefined}
+                              onRowClick={handlePlayerClick}
+                            />
+                          )
+                        )}
+                      </>
                     )}
                   </div>
                   )}

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import React from 'react';
+import { InformationCircleIcon } from '@heroicons/react/24/outline';
+
+export type BadgeColor = 'amber' | 'blue' | 'gray' | 'green' | 'yellow' | 'red' | 'purple';
+
+// Explicit class maps — no dynamic class construction (Tailwind JIT can't see it).
+const COLOR_CLASSES: Record<BadgeColor, string> = {
+  amber: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400',
+  blue: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+  gray: 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-400',
+  green: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+  yellow: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
+  red: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
+  purple: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400',
+};
+
+interface BadgeProps {
+  children: React.ReactNode;
+  color?: BadgeColor;
+  /** 'pill' = fully rounded (default); 'rounded' = lightly rounded corners. */
+  shape?: 'pill' | 'rounded';
+  /**
+   * When set, the badge becomes informational: it shows an info icon and reveals
+   * this text in a small popover on hover/focus (instant — no native-title delay).
+   */
+  tooltip?: string;
+  className?: string;
+}
+
+/** Small label pill. Pass `tooltip` to make it a hoverable info badge. */
+export function Badge({ children, color = 'gray', shape = 'pill', tooltip, className = '' }: BadgeProps) {
+  const pill = `inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium align-middle ${
+    shape === 'pill' ? 'rounded-full' : 'rounded'
+  } ${COLOR_CLASSES[color]}`;
+
+  if (!tooltip) {
+    return <span className={`${pill} ${className}`}>{children}</span>;
+  }
+
+  return (
+    <span className={`group relative inline-flex ${className}`}>
+      <span className={`${pill} cursor-help`} tabIndex={0}>
+        {children}
+        <InformationCircleIcon className="w-3.5 h-3.5" />
+      </span>
+      <span
+        role="tooltip"
+        className="pointer-events-none absolute bottom-full left-0 z-50 mb-1 hidden w-max max-w-xs rounded-md bg-gray-900 px-2 py-1 text-xs font-normal leading-snug text-white shadow-lg group-hover:block group-focus-within:block dark:bg-gray-700"
+      >
+        {tooltip}
+      </span>
+    </span>
+  );
+}
+
+export default Badge;

--- a/src/components/results/RoundStandingsTable.tsx
+++ b/src/components/results/RoundStandingsTable.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import React from 'react';
+import { Table, TableColumn, TableDensity, DensityThresholds } from '@/components/Table';
+import {
+  RoundStandingRow,
+  PlayerInfoDto,
+  formatRatingWithType,
+  getPlayerRatingByAlgorithm,
+  formatPlayerName,
+} from '@/lib/api';
+import { useLanguage } from '@/context/LanguageContext';
+import { getTranslation } from '@/lib/translations';
+
+export interface RoundStandingsTableProps {
+  /** Estimated standings rows for a single round (sorted best-first by the SDK). */
+  rows: RoundStandingRow[];
+  /** Player lookup (built from the official standings' embedded playerInfo). */
+  playerMap: Map<number, PlayerInfoDto>;
+  /** Ranking algorithm for rating display. */
+  rankingAlgorithm?: number | null;
+  /** Callback when a row is clicked (receives the contender row). */
+  onRowClick?: (row: RoundStandingRow) => void;
+  density?: TableDensity;
+  densityThresholds?: DensityThresholds;
+}
+
+/**
+ * Individual round-snapshot standings. Mirrors {@link FinalResultsTable}'s columns
+ * but reads from {@link RoundStandingRow}: primary `points` are exact, while
+ * `qualityPoints` are the SDK's indicative Buchholz/Sonneborn-Berger estimate —
+ * hence the `≈`-badged header and the caveat note rendered by the page.
+ */
+export function RoundStandingsTable({
+  rows,
+  playerMap,
+  rankingAlgorithm,
+  onRowClick,
+  density,
+  densityThresholds,
+}: RoundStandingsTableProps) {
+  const { language } = useLanguage();
+  const t = getTranslation(language);
+  const ft = t.pages.tournamentResults.finalResultsTable;
+  const pb = t.pages.tournamentResults.standingsPlayback;
+
+  const columns: TableColumn<RoundStandingRow>[] = [
+    {
+      id: 'pos',
+      header: ft.pos,
+      accessor: (row) => row.rank,
+      align: 'left',
+      noWrap: true,
+      sortValue: (row) => row.rank,
+    },
+    {
+      id: 'name',
+      header: ft.name,
+      accessor: (row) => {
+        const p = playerMap.get(row.contenderId);
+        return p ? formatPlayerName(p.firstName, p.lastName, p.elo?.title) : `#${row.contenderId}`;
+      },
+      align: 'left',
+      sortValue: (row) => {
+        const p = playerMap.get(row.contenderId);
+        return p ? `${p.lastName} ${p.firstName}`.toLowerCase() : '';
+      },
+    },
+    {
+      id: 'club',
+      header: ft.club,
+      accessor: (row) => playerMap.get(row.contenderId)?.club || '-',
+      align: 'left',
+      cellClassName: 'max-w-[9ch] sm:max-w-none overflow-hidden whitespace-nowrap sm:whitespace-normal',
+      sortValue: (row) => (playerMap.get(row.contenderId)?.club || '').toLowerCase(),
+    },
+    {
+      id: 'ranking',
+      header: ft.ranking,
+      accessor: (row) => {
+        const { rating, ratingType } = getPlayerRatingByAlgorithm(
+          playerMap.get(row.contenderId)?.elo,
+          rankingAlgorithm,
+        );
+        return formatRatingWithType(rating, ratingType, language);
+      },
+      align: 'left',
+      noWrap: true,
+      sortValue: (row) =>
+        getPlayerRatingByAlgorithm(playerMap.get(row.contenderId)?.elo, rankingAlgorithm).rating ?? 0,
+    },
+    {
+      id: 'gp',
+      header: ft.gp,
+      accessor: (row) => row.gamesPlayed || '-',
+      align: 'center',
+      noWrap: true,
+      headerClassName: 'hidden sm:table-cell',
+      cellClassName: 'hidden sm:table-cell',
+    },
+    { id: 'won', header: ft.won, accessor: (row) => row.wins, align: 'center', noWrap: true },
+    { id: 'draw', header: ft.draw, accessor: (row) => row.draws, align: 'center', noWrap: true },
+    { id: 'lost', header: ft.lost, accessor: (row) => row.losses, align: 'center', noWrap: true },
+    {
+      id: 'points',
+      header: ft.points,
+      accessor: (row) => row.points,
+      align: 'center',
+      noWrap: true,
+      cellStyle: { fontWeight: 'medium' },
+      sortValue: (row) => row.points,
+    },
+    {
+      id: 'qp',
+      header: pb.qpHeader,
+      accessor: (row) => (row.qualityPoints != null ? Number(row.qualityPoints).toFixed(1) : '-'),
+      align: 'center',
+      noWrap: true,
+      sortValue: (row) => row.qualityPoints ?? 0,
+    },
+  ];
+
+  return (
+    <Table
+      data={rows}
+      columns={columns}
+      emptyMessage={ft.noResults}
+      onRowClick={onRowClick}
+      getRowKey={(row) => row.contenderId}
+      density={density}
+      densityThresholds={densityThresholds}
+    />
+  );
+}
+
+export default RoundStandingsTable;

--- a/src/components/results/RoundStepper.tsx
+++ b/src/components/results/RoundStepper.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
+
+interface RoundStepperProps {
+  /** Available round numbers, ascending. */
+  rounds: number[];
+  /** Currently selected round. */
+  value: number;
+  /** Called with the newly selected round. */
+  onChange: (round: number) => void;
+  /** Word shown before the number, e.g. "Round" / "Rond". */
+  labelPrefix: string;
+  /** Accessibility label for the previous button. */
+  prevLabel: string;
+  /** Accessibility label for the next button. */
+  nextLabel: string;
+  className?: string;
+}
+
+/**
+ * Compact round scrubber: ◀ "Rond N / total" ▶ plus a slider. Drives the shared
+ * round state, so moving it also moves the round-by-round pairings below.
+ */
+export function RoundStepper({
+  rounds,
+  value,
+  onChange,
+  labelPrefix,
+  prevLabel,
+  nextLabel,
+  className = '',
+}: RoundStepperProps) {
+  if (rounds.length === 0) return null;
+
+  const index = rounds.indexOf(value);
+  const safeIndex = index === -1 ? rounds.length - 1 : index;
+  const canPrev = safeIndex > 0;
+  const canNext = safeIndex < rounds.length - 1;
+
+  const step = (delta: number) => {
+    const next = rounds[safeIndex + delta];
+    if (next !== undefined) onChange(next);
+  };
+
+  return (
+    <div className={`flex items-center gap-3 ${className}`}>
+      <button
+        type="button"
+        onClick={() => canPrev && step(-1)}
+        disabled={!canPrev}
+        className={`p-1.5 rounded-lg transition-colors ${
+          canPrev
+            ? 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800'
+            : 'text-gray-300 dark:text-gray-600 cursor-not-allowed'
+        }`}
+        aria-label={prevLabel}
+      >
+        <ChevronLeftIcon className="w-5 h-5" />
+      </button>
+
+      <span className="text-sm font-medium text-gray-900 dark:text-gray-200 whitespace-nowrap tabular-nums">
+        {labelPrefix} {rounds[safeIndex]} / {rounds[rounds.length - 1]}
+      </span>
+
+      <input
+        type="range"
+        min={0}
+        max={rounds.length - 1}
+        step={1}
+        value={safeIndex}
+        onChange={(e) => onChange(rounds[Number(e.target.value)])}
+        className="flex-1 min-w-[6rem] max-w-[16rem] accent-blue-600 cursor-pointer"
+        aria-label={labelPrefix}
+      />
+
+      <button
+        type="button"
+        onClick={() => canNext && step(1)}
+        disabled={!canNext}
+        className={`p-1.5 rounded-lg transition-colors ${
+          canNext
+            ? 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800'
+            : 'text-gray-300 dark:text-gray-600 cursor-not-allowed'
+        }`}
+        aria-label={nextLabel}
+      >
+        <ChevronRightIcon className="w-5 h-5" />
+      </button>
+    </div>
+  );
+}
+
+export default RoundStepper;

--- a/src/components/results/TeamRoundStandingsTable.tsx
+++ b/src/components/results/TeamRoundStandingsTable.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import React from 'react';
+import { Table, TableColumn, TableDensity, DensityThresholds } from '@/components/Table';
+import { RoundStandingRow } from '@/lib/api';
+import { useLanguage } from '@/context/LanguageContext';
+import { getTranslation } from '@/lib/translations';
+
+export interface TeamRoundStandingsTableProps {
+  /** Estimated team standings rows for a single round (sorted best-first by the SDK). */
+  rows: RoundStandingRow[];
+  /**
+   * Team-name formatter, built from the official team standings via
+   * `createTeamNameFormatter` so multi-team Roman numerals match the final table.
+   */
+  formatTeamName: (contenderId: number, teamNumber: number) => string;
+  /** Callback when a row is clicked (receives the contender row). */
+  onRowClick?: (row: RoundStandingRow) => void;
+  density?: TableDensity;
+  densityThresholds?: DensityThresholds;
+}
+
+/**
+ * Team round-snapshot standings. Mirrors {@link TeamFinalResultsTable}'s columns
+ * from {@link RoundStandingRow}. Team reconstruction is exact (match points + board
+ * points), so — unlike the individual table — there is no estimation badge.
+ */
+export function TeamRoundStandingsTable({
+  rows,
+  formatTeamName,
+  onRowClick,
+  density,
+  densityThresholds,
+}: TeamRoundStandingsTableProps) {
+  const { language } = useLanguage();
+  const t = getTranslation(language);
+  const tt = t.pages.tournamentResults.teamFinalResultsTable;
+
+  const columns: TableColumn<RoundStandingRow>[] = [
+    {
+      id: 'pos',
+      header: tt.pos,
+      accessor: (row) => row.rank,
+      align: 'left',
+      noWrap: true,
+      sortValue: (row) => row.rank,
+    },
+    {
+      id: 'team',
+      header: tt.team,
+      accessor: (row) => formatTeamName(row.contenderId, row.teamNumber ?? 0),
+      align: 'left',
+      sortValue: (row) => formatTeamName(row.contenderId, row.teamNumber ?? 0).toLowerCase(),
+    },
+    {
+      id: 'sp',
+      header: tt.sp,
+      accessor: (row) => row.gamesPlayed || '-',
+      align: 'center',
+      noWrap: true,
+    },
+    { id: 'won', header: tt.won, accessor: (row) => row.wins, align: 'center', noWrap: true },
+    { id: 'draw', header: tt.draw, accessor: (row) => row.draws, align: 'center', noWrap: true },
+    { id: 'lost', header: tt.lost, accessor: (row) => row.losses, align: 'center', noWrap: true },
+    {
+      id: 'pp',
+      header: tt.pp,
+      accessor: (row) => (Math.round(row.points * 2) / 2).toFixed(1),
+      align: 'center',
+      noWrap: true,
+    },
+    {
+      id: 'mp',
+      header: tt.mp,
+      accessor: (row) => (row.matchPoints != null ? row.matchPoints.toFixed(2) : '-'),
+      align: 'center',
+      noWrap: true,
+      cellStyle: { fontWeight: 'medium' },
+      sortValue: (row) => row.matchPoints ?? 0,
+    },
+  ];
+
+  return (
+    <Table
+      data={rows}
+      columns={columns}
+      emptyMessage={tt.noResults}
+      onRowClick={onRowClick}
+      getRowKey={(row) => `${row.contenderId}-${row.teamNumber}`}
+      density={density}
+      densityThresholds={densityThresholds}
+    />
+  );
+}
+
+export default TeamRoundStandingsTable;

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -400,6 +400,17 @@ export interface Translations {
         noResults: string;
         round: string;
       };
+      standingsPlayback: {
+        toggleLabel: string;
+        titleTemplate: string;
+        estimatedBadge: string;
+        qpHeader: string;
+        noteIndividual: string;
+        noteTeam: string;
+        loadError: string;
+        prevRound: string;
+        nextRound: string;
+      };
       print: {
         standings: string;
         rank: string;
@@ -1038,6 +1049,18 @@ const translations: Record<Language, Translations> = {
           noResults: 'No round results available for this group',
           round: 'Round',
         },
+        standingsPlayback: {
+          toggleLabel: 'Round-by-round standings',
+          titleTemplate: 'Standings after round {round}',
+          estimatedBadge: 'estimated',
+          qpHeader: 'QP≈',
+          noteIndividual:
+            'Estimated standings — points are exact, but the secondary score (QP) uses plain Buchholz/Sonneborn-Berger, so the order of tied players may differ from the official {system} tie-break.',
+          noteTeam: 'Estimated standings as of this round, reconstructed from the round results.',
+          loadError: 'Could not load round-by-round standings.',
+          prevRound: 'Previous round',
+          nextRound: 'Next round',
+        },
         print: {
           standings: 'Standings',
           rank: '#',
@@ -1673,6 +1696,18 @@ const translations: Record<Language, Translations> = {
           result: 'Resultat',
           noResults: 'Inga rondresultat tillgängliga för denna grupp',
           round: 'Rond',
+        },
+        standingsPlayback: {
+          toggleLabel: 'Ställning per rond',
+          titleTemplate: 'Ställning efter rond {round}',
+          estimatedBadge: 'uppskattad',
+          qpHeader: 'KP≈',
+          noteIndividual:
+            'Uppskattad ställning – poängen är exakta, men sekundärpoängen (KP) använder enkel Buchholz/Sonneborn-Berger, så ordningen mellan poänglika spelare kan avvika från det officiella särskiljningssystemet {system}.',
+          noteTeam: 'Uppskattad ställning efter denna rond, rekonstruerad från rondresultaten.',
+          loadError: 'Det gick inte att ladda ställning per rond.',
+          prevRound: 'Föregående rond',
+          nextRound: 'Nästa rond',
         },
         print: {
           standings: 'Ställning',


### PR DESCRIPTION
## What

An opt-in **playback** in the tournament group view: scrub through a finished tournament's rounds and watch how the standings evolved. The official standings table stays the default — playback is never shown by default.

Built on `@msvens/schack-se-sdk` **0.8.0**'s new `getRoundStandings(groupId)`, which reconstructs one standings snapshot per round.

## How it works

- A **"round-by-round standings"** toggle appears in the standings header — **only for finished events**, on purpose: during an ongoing event the live-updates toggle occupies that spot, and a playback toggle beside it (live-now vs. scrub-history) is confusing. Gating to finished means the two never coexist.
- When on, a **round stepper + slider** drives the page's shared `selectedRound`, so the round pairings below move in lockstep — the whole page reflects "round N".
- The official table is swapped for a per-round snapshot table (individual or team).

## Honesty about estimation

Per the SDK: **team** snapshots are exact; **individual primary points are exact**, but the **secondary/quality points are indicative** — it uses plain Buchholz/Sonneborn-Berger, not SSF's exact tie-break variant, so point-tied players may be ordered differently. This is surfaced with an **"estimated" badge** (fast CSS tooltip) and a note naming the official system via `getTiebreakSystemName(group.tiebreakSystem)`. Authoritative standings still come from `getTournamentResults`.

## Notable pieces

- `RoundStandingsTable` / `TeamRoundStandingsTable` render over the generic `Table`, reusing the context `playerMap` and an official-standings-derived team-name formatter (no extra fetches for names).
- Round standings are **fetched lazily** only when playback is first enabled, and tagged by `groupId` so switching group refetches.
- New shared **`Badge`** component (color + shape + instant CSS tooltip); the changelog's `SectionBadge` is refactored onto it.
- Gated off for not-started, single-round, Schackfyran, and loose-team events.

## Verification

- `pnpm check` green: typecheck, lint, 62 tests, build.
- `getRoundStandings` exercised against live data (groups 18780, 18065, 18593): correct per-round snapshots, exact points + Buchholz quality points, ~150ms.

## Follow-up

If the SDK later implements the exact SSF tie-break algorithms, the "estimated" framing can be retired (the page already reads `group.tiebreakSystem`).