### PR TITLE
SDK 0.9.1: SDK-driven estimation framing + team playback fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
-    "@msvens/schack-se-sdk": "github:msvens/schack-se-sdk#v0.8.0",
+    "@msvens/schack-se-sdk": "github:msvens/schack-se-sdk#v0.9.1",
     "leaflet": "^1.9.4",
     "leaflet.markercluster": "^1.5.3",
     "next": "16.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0(react@19.2.4)
       '@msvens/schack-se-sdk':
-        specifier: github:msvens/schack-se-sdk#v0.8.0
-        version: https://codeload.github.com/msvens/schack-se-sdk/tar.gz/8309ada7e3e7a6130d63814f64fbbf2a26c2ab64
+        specifier: github:msvens/schack-se-sdk#v0.9.1
+        version: https://codeload.github.com/msvens/schack-se-sdk/tar.gz/8ce9191c9124afa764b0b40385aca120e913d088
       leaflet:
         specifier: ^1.9.4
         version: 1.9.4
@@ -634,9 +634,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@msvens/schack-se-sdk@https://codeload.github.com/msvens/schack-se-sdk/tar.gz/8309ada7e3e7a6130d63814f64fbbf2a26c2ab64':
-    resolution: {tarball: https://codeload.github.com/msvens/schack-se-sdk/tar.gz/8309ada7e3e7a6130d63814f64fbbf2a26c2ab64}
-    version: 0.8.0
+  '@msvens/schack-se-sdk@https://codeload.github.com/msvens/schack-se-sdk/tar.gz/8ce9191c9124afa764b0b40385aca120e913d088':
+    resolution: {tarball: https://codeload.github.com/msvens/schack-se-sdk/tar.gz/8ce9191c9124afa764b0b40385aca120e913d088}
+    version: 0.9.1
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -3358,7 +3358,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@msvens/schack-se-sdk@https://codeload.github.com/msvens/schack-se-sdk/tar.gz/8309ada7e3e7a6130d63814f64fbbf2a26c2ab64': {}
+  '@msvens/schack-se-sdk@https://codeload.github.com/msvens/schack-se-sdk/tar.gz/8ce9191c9124afa764b0b40385aca120e913d088': {}
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:

--- a/src/app/results/[tournamentId]/[groupId]/page.tsx
+++ b/src/app/results/[tournamentId]/[groupId]/page.tsx
@@ -149,11 +149,14 @@ export default function GroupResultsPage() {
     }, {} as Record<number, TournamentRoundResultDto[]>);
   }, [isTeamTournament, individualRoundResults]);
 
-  // Sorted list of round numbers we have data for.
-  const sortedRounds = useMemo(
-    () => Object.keys(resultsByRound).map(Number).sort((a, b) => a - b),
-    [resultsByRound]
-  );
+  // Sorted list of round numbers we have data for. Derived from the active
+  // result set per type — team round data lives in teamRoundResults, not in
+  // resultsByRound (which is individual-only), so deriving solely from the
+  // latter left sortedRounds empty for team events and disabled their playback.
+  const sortedRounds = useMemo(() => {
+    const rows = isTeamTournament ? teamRoundResults : individualRoundResults;
+    return [...new Set(rows.map((r) => r.roundNr || 1))].sort((a, b) => a - b);
+  }, [isTeamTournament, teamRoundResults, individualRoundResults]);
 
   // The round currently being viewed. `selectedRound` holds the user's
   // explicit click (null until they click); otherwise we fall back to the
@@ -433,12 +436,17 @@ export default function GroupResultsPage() {
       ? roundStandings.byRound.get(activeRound) ?? null
       : null;
   const showPlayback = playbackEligible && playbackEnabled;
+  // Estimation framing is driven ENTIRELY by the SDK's per-snapshot flags — no
+  // team/individual or tie-break logic here. `estimated === false` (team-exact or
+  // a confirmed official basis) → no badge/note; otherwise the wording is chosen
+  // from `secondaryBasis`. `tiebreakName` is only a display label for the note.
   const tiebreakName = group ? getTiebreakSystemName(group.tiebreakSystem) : '';
-  // Explicit caveat copy — shown both as the "estimated" badge tooltip and as a
-  // visible note under the snapshot table.
-  const playbackNote = isTeamTournament
-    ? t.pages.tournamentResults.standingsPlayback.noteTeam
-    : t.pages.tournamentResults.standingsPlayback.noteIndividual.replace('{system}', tiebreakName);
+  const playbackNote = (() => {
+    if (!activeSnapshot?.estimated) return null;
+    const pb = t.pages.tournamentResults.standingsPlayback;
+    const base = activeSnapshot.secondaryBasis === 'indicative' ? pb.noteIndicative : pb.noteReproduced;
+    return base.replace('{system}', tiebreakName);
+  })();
 
   // Handle row click in final results table - navigate to player detail page
   const handlePlayerClick = (result: TournamentEndResultDto) => {
@@ -616,7 +624,7 @@ export default function GroupResultsPage() {
                                 : isFinished
                                   ? t.pages.tournamentResults.finalResults
                                   : t.pages.tournamentResults.ongoingResults}{!isSingleGroup && ` - ${selectedGroup.name}`}
-                            {showPlayback && (
+                            {showPlayback && playbackNote && (
                               <Badge color="amber" tooltip={playbackNote} className="ml-2">
                                 {t.pages.tournamentResults.standingsPlayback.estimatedBadge}
                               </Badge>
@@ -746,9 +754,11 @@ export default function GroupResultsPage() {
                             onRowClick={handleSnapshotPlayerClick}
                           />
                         )}
-                        <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
-                          {playbackNote}
-                        </p>
+                        {playbackNote && (
+                          <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
+                            {playbackNote}
+                          </p>
+                        )}
                       </div>
                     ) : (
                       <>

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -405,8 +405,10 @@ export interface Translations {
         titleTemplate: string;
         estimatedBadge: string;
         qpHeader: string;
-        noteIndividual: string;
-        noteTeam: string;
+        /** Shown when secondaryBasis === 'reproduced' (SSF method, pending confirmation). */
+        noteReproduced: string;
+        /** Shown when secondaryBasis === 'indicative' (rough generic stand-in). */
+        noteIndicative: string;
         loadError: string;
         prevRound: string;
         nextRound: string;
@@ -1054,9 +1056,10 @@ const translations: Record<Language, Translations> = {
           titleTemplate: 'Standings after round {round}',
           estimatedBadge: 'estimated',
           qpHeader: 'QP≈',
-          noteIndividual:
-            'Estimated standings — points are exact, but the secondary score (QP) uses plain Buchholz/Sonneborn-Berger, so the order of tied players may differ from the official {system} tie-break.',
-          noteTeam: 'Estimated standings as of this round, reconstructed from the round results.',
+          noteReproduced:
+            'Points are exact. The secondary score (QP) reproduces SSF’s official {system} method and matches the official result closely, though the very deepest ties may differ slightly.',
+          noteIndicative:
+            'Points are exact. The secondary score (QP) is a rough Buchholz/Sonneborn-Berger estimate, so among players on equal points the order may differ from the official {system}.',
           loadError: 'Could not load round-by-round standings.',
           prevRound: 'Previous round',
           nextRound: 'Next round',
@@ -1702,9 +1705,10 @@ const translations: Record<Language, Translations> = {
           titleTemplate: 'Ställning efter rond {round}',
           estimatedBadge: 'uppskattad',
           qpHeader: 'KP≈',
-          noteIndividual:
-            'Uppskattad ställning – poängen är exakta, men sekundärpoängen (KP) använder enkel Buchholz/Sonneborn-Berger, så ordningen mellan poänglika spelare kan avvika från det officiella särskiljningssystemet {system}.',
-          noteTeam: 'Uppskattad ställning efter denna rond, rekonstruerad från rondresultaten.',
+          noteReproduced:
+            'Poängen är exakta. Sekundärpoängen (KP) återskapar SSF:s officiella {system}-metod och stämmer mycket nära det officiella resultatet, men de allra djupaste delningarna kan avvika något.',
+          noteIndicative:
+            'Poängen är exakta. Sekundärpoängen (KP) är en grov uppskattning (Buchholz/Sonneborn-Berger), så bland spelare med lika poäng kan ordningen avvika från det officiella ({system}).',
           loadError: 'Det gick inte att ladda ställning per rond.',
           prevRound: 'Föregående rond',
           nextRound: 'Nästa rond',


### PR DESCRIPTION
## What

Bumps `@msvens/schack-se-sdk` **0.8.0 → 0.9.1** and uses its new round-standings metadata so the playback's "estimated" framing is decided entirely by the SDK — the app no longer contains any team-vs-individual or tie-break logic for this.

## The 0.9.x story

0.9.0 reverse-engineered SSF's official `secPoints` (currently SSF Buchholz; matches official to ~1e-5 — identical at the 1-decimal we display). 0.9.1 then added the per-snapshot signal we need:

- `RoundStandings.estimated: boolean`
- `RoundStandings.secondaryBasis: 'exact' | 'official' | 'reproduced' | 'indicative'`

## App changes

- **Estimation badge + note are now flag-driven.** `estimated === false` (team-exact, or a confirmed official basis) → no badge, no note. `estimated === true` → badge + a note chosen from `secondaryBasis` (`indicative` → rough Buchholz/Sonneborn-Berger estimate; otherwise → "reproduces SSF's official {system} method, matches closely, deepest ties may differ"). Removed the old `isTeamTournament ? … : …` branch entirely.
- **Bug fix: team playback never appeared.** `sortedRounds` was derived only from `individualRoundResults` (empty for team tournaments), so the `>= 2 rounds` eligibility gate suppressed playback for *every* team event. Now derived from the active result set per type (`teamRoundResults` for team). E.g. Stockholmsserien 2025/2026 (6084) now shows it.
- Reworded the note to reflect the improved reproduction; dropped the "pending SSF confirmation" phrasing.

## Verification

- `pnpm check` green: typecheck, lint, 62 tests, build.
- Live flags confirmed: team group 17039 → `estimated:false / exact` (no badge); individual SSF Buchholz 15816 & 18065 → `estimated:true / reproduced` (badge + note).

No app-side tie-break knowledge: the SDK owns exact-vs-estimate; `isSsfSecPointsSupported` stays internal.